### PR TITLE
Facilitate RPM (and other distro) generation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,12 @@ project(
   'c',
   version : '0.6.0',
   default_options : ['c_std=c11', 'warning_level=3'],
+  license : 'GPL-2.0+ OR LGPL-2.1+ OR MIT',
+  license_files : [
+    'LICENSES/GPL-2.0-only.txt',
+    'LICENSES/LGPL-2.1-only.txt',
+    'LICENSES/MIT.txt'
+  ]
 )
 project_description = 'Library to interact with the Microsoft Device Broker for SSO'
 

--- a/meson.build
+++ b/meson.build
@@ -85,7 +85,8 @@ sso_mib_tool = executable(
   install : true,
   include_directories : public_headers,
   link_with : [libsso_mib],
-  dependencies: [glibdep, giodep, jsondep, uuiddep]
+  dependencies: [glibdep, giodep, jsondep, uuiddep],
+  install_tag : 'tool'
 )
 
 if get_option('documentation')


### PR DESCRIPTION
Meson can model a substantial amount of information useful for an RPM `.spec` file or for other distribution packaging schemes.
The `meson introspect` command exports this information as JSON that can be transformed, e.g., into a `.spec` file.

This pull request adds some information to sso-mib's `meson.build` to facilitate this.

The commits have the following purpose:

  1) [Added project's license information to meson.build](https://github.com/siemens/sso-mib/commit/6d145a782852511e4dde5686151d0a50da0afef7) fills in the project's `license` and `license_files` slots.

  2) [Added a meson install_tag to sso_mib_tool](https://github.com/siemens/sso-mib/pull/9/commits/35da2acb0970bd4805b2e2771d70bf70b87cf0a0) marks the executable `sso-mib-tool` with a separate `install_tag`. 
  In Meson,  _install tags_ can be used to install only a subset of the targets with the `--tags` option. 
  `.spec` file generation can use install tags to derive sub-packaging information.

  ~~3) [Have git-archive set the project version from the latest v%d.%d.%d ta…](https://github.com/siemens/sso-mib/commit/5191327be05a558015c070a34fe523d0be4cf167) uses `git-archive`'s substitution feature to automatically update the project's version from the latest release tag.  Note that this requires `git-archive` to actually produce an archive; the `meson.build` file in the repo remains unchanged.  To avoid problems, a fallback version of 0.0.1 is used in this case.~~
  
~~Unfortunately, limitations of meson and `git-archive` force a convoluted code structure:~~

~~- The very first statement in `meson.build` must be `project()`.  This makes it impossible to move the version fallback code ahead of the `project()` statement.  Also, Meson's string manipulation is limited, e.g., regular expressions are not supported, which makes it impossible to remove dirty suffixes from the version string.  On the other hand, this enforces proper release tagging.~~

 ~~- `git-archive` expands only a single instance of the `describe` keyword (which works similarly to `git-describe`).  This is to avoid denial-of-service attacks -- although why they couldn't calculate this once and cache the result is beyond me.~~
 
 ~~This third commit is not necessary for RPM generation and could be dropped.~~

