### PR TITLE
ci(nix): add flake and dedicated CI job for reproducible builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           reuse lint
 
-  build:
+  build-ubuntu:
     runs-on: ubuntu-24.04
     steps:
       - name: checkout repository
@@ -71,6 +71,18 @@ jobs:
         id: deployment
         with:
           path: build/api/
+
+  build-nix:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+      - name: Build with Nix
+        run: nix build
 
   package:
     strategy:
@@ -152,7 +164,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-24.04
-    needs: build
+    needs: build-ubuntu
     permissions:
       pages: write
       id-token: write

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -10,7 +10,7 @@ SPDX-FileCopyrightText = "2025 Siemens AG"
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]
-path = ["README.md", "dbus/spec/com.microsoft.identity.broker1.xml"]
+path = ["README.md", "dbus/spec/com.microsoft.identity.broker1.xml", "flake.lock"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2025 Siemens AG"
 SPDX-License-Identifier = "MIT"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1764844358,
+        "narHash": "sha256-mlyHRZk8LN5OeyESAS98RMu/2Ectz5sezqCmHQBmbIo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "af6e791c2bd918567b48f65b1873bc44b6d331e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "id": "systems",
+        "type": "indirect"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: (C) 2025 Siemens
+# SPDX-License-Identifier: MIT
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/release-25.11";
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      systems,
+      ...
+    }@inputs:
+    let
+      inherit (nixpkgs) lib;
+      eachSystem = lib.genAttrs (import systems);
+      pkgsFor = eachSystem (
+        system:
+        import nixpkgs {
+          localSystem.system = system;
+          overlays = with self.overlays; [ default ];
+        }
+      );
+    in
+    {
+      overlays = import ./nix/overlays.nix { inherit inputs lib self; };
+
+      packages = eachSystem (system: {
+        default = self.packages.${system}.sso-mib;
+        inherit (pkgsFor.${system}) sso-mib;
+      });
+
+      devShells = eachSystem (
+        system:
+        let
+          pkgs = pkgsFor.${system};
+        in
+        pkgs.mkShell {
+          inherit (pkgs.sso-mib) buildInputs nativeBuildInputs;
+        }
+      );
+    };
+}

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: (C) 2025 Siemens
+# SPDX-License-Identifier: MIT
+{
+  lib,
+  inputs,
+  self,
+}:
+
+let
+  mkDate =
+    longDate:
+    (lib.concatStringsSep "-" [
+      (builtins.substring 0 4 longDate)
+      (builtins.substring 4 2 longDate)
+      (builtins.substring 6 2 longDate)
+    ]);
+
+  lines = lib.strings.splitString "\n" (builtins.readFile ../meson.build);
+  matchVersion = lib.strings.match "[ ]*version[ ]*:.*([0-9]+\.[0-9]+\.[0-9]+).*";
+  version = builtins.head (
+    lib.lists.findFirst (x: !builtins.isNull x) "git" (lib.lists.map matchVersion lines)
+  );
+in
+
+{
+  default = inputs.self.overlays.sso-mib;
+  sso-mib = final: prev: {
+    sso-mib = prev.callPackage ./sso-mib.nix {
+      version =
+        version
+        + "+date="
+        + (mkDate (inputs.self.lastModifiedDate or "19700101"))
+        + "_"
+        + (inputs.self.shortRev or "dirty");
+    };
+  };
+}

--- a/nix/sso-mib.nix
+++ b/nix/sso-mib.nix
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: (C) 2025 Siemens
+# SPDX-License-Identifier: MIT
+{
+  lib,
+  stdenv,
+  meson,
+  ninja,
+  pkg-config,
+  libjwt,
+  libuuid,
+  glib,
+  json-glib,
+  version ? "git",
+}:
+
+stdenv.mkDerivation {
+  pname = "sso-mib";
+  inherit version;
+
+  src = ../.;
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+  ];
+
+  buildInputs = [
+    libjwt
+    libuuid
+    glib
+    json-glib
+  ];
+
+  meta = with lib; {
+    homepage = "https://github.com/siemens/sso-mib";
+    description = "C library to interact with a locally running microsoft-identity-broker to get various authentication tokens via DBus.";
+    maintainers = [ maintainers.michaeladler ];
+    platforms = platforms.all;
+    license = [
+      licenses.gpl2Only
+      licenses.lgpl21Only
+    ];
+  };
+}


### PR DESCRIPTION
- Enable fully reproducible builds via flake.nix
- Allow Nix users to build/run sso-mib-tool without manual setup
- Add GitHub Actions job running inside Nix to detect implicit dependencies and non-portable compiler assumptions