### PR TITLE
Meson: Licensing info & automatic Version update

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/meson.build export-subst

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,12 @@
 project(
   'sso-mib',
   'c',
-  version : '0.7.0',
+  version : '$Format:%H$'.contains ('Format:%')?
+      '0.0.1': '$Format:%(describe:match=v*.*.*)$'.substring(1),
+      # The version string must have the format %d.%d.%d,
+      # fallback to 0.0.1
+      # git-archive will expand at most one $Format:%(describe)$
+      # to avoid denial-of-service attacks
   default_options : ['c_std=gnu11', 'warning_level=3'],
   license : 'GPL-2.0+ OR LGPL-2.1+ OR MIT',
   license_files : [

--- a/meson.build
+++ b/meson.build
@@ -3,10 +3,20 @@
 project(
   'sso-mib',
   'c',
-  version : '$Format:%H$'.contains ('Format:%')?
-      '0.0.1': '$Format:%(describe:match=v*.*.*)$'.substring(1),
+  version : ('$Format:%H$'.contains ('Format:%')?
+      run_command([
+        'git',
+        'describe',
+        '--match=v*.*.*',
+        '--abbrev=0'],
+        check: true,
+        env: {
+          'GIT_WORK_TREE': meson.project_source_root ()
+        }
+      ).stdout().strip() :
+     '$Format:%(describe:match=v*.*.*)$').substring(1),
       # The version string must have the format %d.%d.%d,
-      # fallback to 0.0.1
+      # fallback to highest version tag.
       # git-archive will expand at most one $Format:%(describe)$
       # to avoid denial-of-service attacks
   default_options : ['c_std=gnu11', 'warning_level=3'],

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,12 @@ project(
   'c',
   version : '0.7.0',
   default_options : ['c_std=gnu11', 'warning_level=3'],
+  license : 'GPL-2.0+ OR LGPL-2.1+ OR MIT',
+  license_files : [
+    'LICENSES/GPL-2.0-only.txt',
+    'LICENSES/LGPL-2.1-only.txt',
+    'LICENSES/MIT.txt'
+  ]
 )
 project_description = 'Library to interact with the Microsoft Device Broker for SSO'
 add_project_arguments('-Wno-unused-parameter', language : 'c')


### PR DESCRIPTION
The first commit simply adds license information to the appropriate Meson project header field.  This in itself provides no additional functionality.  It was however used to populate the equivalent fields in the RPM build script.  (I've written a `jq` script that transforms `meson introspect` information into the starting point of an RPM script.)

The second and third commits derive the Meson version from the corresponding git tag using the `git archive` substitution mechanism.
This ensures that the Git tag and the version in `meson.build` are in sync.  Meson always requires a 3-part decimal tag; when not retrieving the source tarball through `git archive`, the final commit uses `git describe` to create a suitable fallback version number dynamically.

The code is complicated by the fact that `git archive` will only ever expand one `git describe` when creating an archive (perhaps to deter denial-of-service attacks) and that the Meson language prevents the use of variables before it first configuration section.