### PR TITLE
fix(git-cred-helper): ask for consent if needed when acquiring token

### DIFF
--- a/examples/smtp-o365/main.c
+++ b/examples/smtp-o365/main.c
@@ -102,7 +102,6 @@ int main(int argc, char **argv)
 		goto cleanup;
 
 	mib_client_app_set_redirect_uri(app, APP_REDIRECT_URI);
-	scopes = g_slist_append(scopes, "offline_access");
 	scopes = g_slist_append(scopes, "https://outlook.office365.com/SMTP.Send");
 
 	token = mib_client_app_acquire_token_interactive(

--- a/examples/smtp-o365/main.c
+++ b/examples/smtp-o365/main.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
 	scopes = g_slist_append(scopes, "https://outlook.office365.com/SMTP.Send");
 
 	token = mib_client_app_acquire_token_interactive(
-		app, scopes, MIB_PROMPT_NONE, input.username, NULL, NULL, NULL);
+		app, scopes, MIB_PROMPT_UNSET, input.username, NULL, NULL, NULL);
 	if (!token) {
 		g_printerr("could not get token\n");
 		goto cleanup;


### PR DESCRIPTION
First time users need to grant permissions to the application. This currently fails, as we explicitly request the token without prompting the user. By that, no token can be returned in this case.

We fix this by not setting the OIDC prompt parameter. By that, the implementation should ask for consent if needed.
