### PR TITLE
Add async variants of the blocking DBus calls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,18 @@ jobs:
           meson setup -Ddocumentation=True -Dexamples=True build
           cd build && ninja
 
+      - name: test with address sanitizer
+        run: |
+          meson setup -Db_sanitize=address -Ddocumentation=false -Dexamples=false build-asan
+          ninja -C build-asan
+          meson test -C build-asan
+
+      - name: test with undefined behavior sanitizer
+        run: |
+          meson setup -Db_sanitize=undefined -Ddocumentation=false -Dexamples=false build-ubsan
+          ninja -C build-ubsan
+          meson test -C build-ubsan
+
       - name: upload API docs
         uses: actions/upload-pages-artifact@v5
         id: deployment

--- a/docs/doxygen.in
+++ b/docs/doxygen.in
@@ -30,3 +30,4 @@ PREDEFINED             = PUBLIC_API= DOXYGEN=1 G_BEGIN_DECLS G_END_DECLS
 EXCLUDE_SYMBOLS        = PUBLIC_API _SSO_MIB_INSIDE_ G_BEGIN_DECLS G_END_DECLS
 STRIP_FROM_PATH        = "@apisrcdir@"
 ALIASES               += dbuscall{1}="\note Synchronous DBus call to \c \1"
+ALIASES               += dbusacall{1}="\note Asynchronous DBus call to \c \1"

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -20,3 +20,12 @@ example_onedrive = executable(
   link_with : [libsso_mib],
   dependencies: [glibdep, giodep, uuiddep, curldep, jsondep]
 )
+
+example_token_async = executable(
+  'mib-example-token-async',
+  'token-async/main.c',
+  install : false,
+  include_directories : public_headers,
+  link_with : [libsso_mib],
+  dependencies: [glibdep, giodep]
+)

--- a/examples/token-async/main.c
+++ b/examples/token-async/main.c
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: (C) 2026 Siemens
+ * SPDX-License-Identifier: MIT
+ *
+ * This example demonstrates how to acquire a token asynchronously using
+ * the GAsyncReadyCallback pattern with chained async operations.
+ * A periodic GSource prints progress dots on the default main context
+ * while the request is in-flight.
+ */
+
+#include "sso-mib.h"
+#include <stdio.h>
+
+#define EDGE_BROWSER_CLIENT_ID "d7b530a4-7680-4c23-a8bf-c52c121d2e87"
+
+typedef struct {
+	GSList *scopes;
+	gboolean done;
+} AsyncContext;
+
+static gboolean print_dot(gpointer user_data)
+{
+	AsyncContext *ctx = user_data;
+	if (ctx->done)
+		return G_SOURCE_REMOVE;
+	g_print(".");
+	fflush(stdout);
+	return G_SOURCE_CONTINUE;
+}
+
+static void on_token_acquired(GObject *source_object, GAsyncResult *res,
+							  gpointer user_data)
+{
+	AsyncContext *ctx = user_data;
+	MIBClientApp *app = MIB_CLIENT_APP(source_object);
+	GError *error = NULL;
+
+	MIBPrt *prt = mib_client_app_acquire_token_silent_finish(app, res, &error);
+	if (!prt) {
+		g_printerr("Failed to acquire token: %s\n", error->message);
+		g_error_free(error);
+	} else {
+		g_print("Access token: %s\n", mib_prt_get_access_token(prt));
+		g_object_unref(prt);
+	}
+
+	ctx->done = TRUE;
+}
+
+static void on_accounts_ready(GObject *source_object, GAsyncResult *res,
+							  gpointer user_data)
+{
+	AsyncContext *ctx = user_data;
+	MIBClientApp *app = MIB_CLIENT_APP(source_object);
+	GError *error = NULL;
+
+	GSList *accounts = mib_client_app_get_accounts_finish(app, res, &error);
+	if (!accounts) {
+		g_printerr("Failed to get accounts: %s\n",
+				   error ? error->message : "no accounts registered");
+		g_clear_error(&error);
+		ctx->done = TRUE;
+		return;
+	}
+
+	MIBAccount *account = g_slist_nth_data(accounts, 0);
+	if (!account) {
+		g_printerr("No account is registered\n");
+		g_slist_free_full(accounts, (GDestroyNotify)g_object_unref);
+		ctx->done = TRUE;
+		return;
+	}
+
+	/* chain: acquire token asynchronously */
+	mib_client_app_acquire_token_silent_async(
+		app, account, ctx->scopes, NULL, NULL, NULL, on_token_acquired, ctx);
+	g_slist_free_full(accounts, (GDestroyNotify)g_object_unref);
+}
+
+int main(void)
+{
+	const gchar *authority = MIB_AUTHORITY_COMMON;
+	AsyncContext ctx = { .scopes = NULL, .done = FALSE };
+
+	MIBClientApp *app = mib_public_client_app_new(EDGE_BROWSER_CLIENT_ID,
+												  authority, NULL, NULL);
+	if (!app) {
+		g_printerr("Failed to create client app\n");
+		return -1;
+	}
+
+	ctx.scopes = g_slist_append(NULL, g_strdup("User.Read"));
+
+	/* start the async chain: get accounts, then acquire token */
+	mib_client_app_get_accounts_async(app, on_accounts_ready, &ctx);
+
+	/* print dots while the request is in-flight */
+	g_timeout_add(50, print_dot, &ctx);
+
+	/* iterate the main context until all async work completes */
+	while (!ctx.done)
+		g_main_context_iteration(NULL, TRUE);
+
+	g_slist_free_full(ctx.scopes, g_free);
+	g_object_unref(app);
+	return 0;
+}

--- a/include/mib-client-app.h
+++ b/include/mib-client-app.h
@@ -25,7 +25,7 @@
  *  @{
  */
 
- /**
+/**
  * \brief Common authority for all tenants
  */
 #define MIB_AUTHORITY_COMMON "https://login.microsoftonline.com/common"
@@ -110,8 +110,8 @@ mib_client_app_get_broker_redirect_uri(const MIBClientApp *self);
  * \note The redirect URI must be in the list of allowed redirect URIs for
  *       the target application. Otherwise, the token acquisition will not work.
  */
-PUBLIC_API void
-mib_client_app_set_redirect_uri(MIBClientApp* self, const gchar* uri);
+PUBLIC_API void mib_client_app_set_redirect_uri(MIBClientApp *self,
+												const gchar *uri);
 
 /**
  * \brief Get the version of the Linux broker

--- a/include/mib-client-app.h
+++ b/include/mib-client-app.h
@@ -127,6 +127,33 @@ mib_client_app_get_linux_broker_version(MIBClientApp *app,
 										const gchar *msal_cpp_version);
 
 /**
+ * \brief Get the version of the Linux broker (async)
+ *
+ * Asynchronous variant of \ref mib_client_app_get_linux_broker_version.
+ *
+ * \dbusacall{getLinuxBrokerVersion}
+ *
+ * \param app client app object
+ * \param msal_cpp_version MSAL CPP version (non-empty string, e.g. 1.28.0)
+ * \param callback a GAsyncReadyCallback to call when the request is done
+ * \param user_data user data to pass to the callback
+ */
+PUBLIC_API void mib_client_app_get_linux_broker_version_async(
+	MIBClientApp *app, const gchar *msal_cpp_version,
+	GAsyncReadyCallback callback, gpointer user_data);
+
+/**
+ * \brief Finish an async get Linux broker version operation
+ *
+ * \param app client app object
+ * \param result the GAsyncResult passed to the callback
+ * \param error return location for a GError or NULL
+ * \return broker version (or null on error, must be freed with g_free())
+ */
+PUBLIC_API gchar *mib_client_app_get_linux_broker_version_finish(
+	MIBClientApp *app, GAsyncResult *result, GError **error);
+
+/**
  * \brief Get the accounts associated with the session
  *
  * Returns a list of \ref MIBAccount entries associated with the application.
@@ -141,6 +168,41 @@ mib_client_app_get_linux_broker_version(MIBClientApp *app,
  * \return list of \ref MIBAccount*
  */
 PUBLIC_API GSList *mib_client_app_get_accounts(MIBClientApp *app);
+
+/**
+ * \brief Get the accounts associated with the session (async)
+ *
+ * Asynchronous variant of \ref mib_client_app_get_accounts.
+ * When the operation is finished, \p callback will be called.
+ * You can then call \ref mib_client_app_get_accounts_finish to get
+ * the result.
+ *
+ * \dbusacall{getAccounts}
+ *
+ * \param app client app object
+ * \param callback a GAsyncReadyCallback to call when the request is done
+ * \param user_data user data to pass to the callback
+ */
+PUBLIC_API void mib_client_app_get_accounts_async(MIBClientApp *app,
+												  GAsyncReadyCallback callback,
+												  gpointer user_data);
+
+/**
+ * \brief Finish an async get accounts operation
+ *
+ * Finishes an operation started with \ref mib_client_app_get_accounts_async.
+ *
+ * The user is responsible for freeing the list, e.g. with
+ * \c g_slist_free_full(accounts,(GDestroyNotify)g_object_unref)
+ *
+ * \param app client app object
+ * \param result the GAsyncResult passed to the callback
+ * \param error return location for a GError or NULL
+ * \return list of \ref MIBAccount* or NULL on error
+ */
+PUBLIC_API GSList *mib_client_app_get_accounts_finish(MIBClientApp *app,
+													  GAsyncResult *result,
+													  GError **error);
 
 /**
  * \brief Filter the registered accounts by UPN and return the first match
@@ -180,6 +242,40 @@ PUBLIC_API MIBPrt *mib_client_app_acquire_token_silent(
 	MIBClientApp *app, MIBAccount *account, GSList *scopes,
 	const gchar *claims_challenge, MIBPopParams *auth_scheme,
 	const gchar *id_token);
+
+/**
+ * \brief Acquire a token without user interaction (async)
+ *
+ * Asynchronous variant of \ref mib_client_app_acquire_token_silent.
+ *
+ * \dbusacall{acquireTokenSilently}
+ *
+ * \param app client app object
+ * \param account mib account reference
+ * \param scopes list of scopes (\c gchar* entries)
+ * \param claims_challenge claims challenge or NULL
+ * \param auth_scheme PoP parameters or NULL
+ * \param id_token ID token or NULL
+ * \param callback a GAsyncReadyCallback to call when the request is done
+ * \param user_data user data to pass to the callback
+ */
+PUBLIC_API void mib_client_app_acquire_token_silent_async(
+	MIBClientApp *app, MIBAccount *account, GSList *scopes,
+	const gchar *claims_challenge, MIBPopParams *auth_scheme,
+	const gchar *id_token, GAsyncReadyCallback callback, gpointer user_data);
+
+/**
+ * \brief Finish an async silent token acquisition
+ *
+ * The user is responsible for freeing the object with \c g_object_unref .
+ *
+ * \param app client app object
+ * \param result the GAsyncResult passed to the callback
+ * \param error return location for a GError or NULL
+ * \return PRT token struct or NULL on error
+ */
+PUBLIC_API MIBPrt *mib_client_app_acquire_token_silent_finish(
+	MIBClientApp *app, GAsyncResult *result, GError **error);
 
 /**
  * \brief Acquire a token without with user interaction (if needed)
@@ -227,6 +323,37 @@ mib_client_app_acquire_prt_sso_cookie(MIBClientApp *app, MIBAccount *account,
 									  const gchar *sso_url, GSList *scopes);
 
 /**
+ * \brief Acquire a PRT SSO cookie (async)
+ *
+ * Asynchronous variant of \ref mib_client_app_acquire_prt_sso_cookie.
+ *
+ * \dbusacall{acquirePrtSsoCookie}
+ *
+ * \param app client app object
+ * \param account mib account reference
+ * \param sso_url SSO URL
+ * \param scopes list of scopes
+ * \param callback a GAsyncReadyCallback to call when the request is done
+ * \param user_data user data to pass to the callback
+ */
+PUBLIC_API void mib_client_app_acquire_prt_sso_cookie_async(
+	MIBClientApp *app, MIBAccount *account, const gchar *sso_url,
+	GSList *scopes, GAsyncReadyCallback callback, gpointer user_data);
+
+/**
+ * \brief Finish an async PRT SSO cookie acquisition
+ *
+ * The user is responsible for freeing the object with \c g_object_unref .
+ *
+ * \param app client app object
+ * \param result the GAsyncResult passed to the callback
+ * \param error return location for a GError or NULL
+ * \return PRT SSO cookie struct or NULL on error
+ */
+PUBLIC_API MIBPrtSsoCookie *mib_client_app_acquire_prt_sso_cookie_finish(
+	MIBClientApp *app, GAsyncResult *result, GError **error);
+
+/**
  * \brief Generate a signed HTTP request
  *
  * This function implements the Acquiring Access Tokens Protected with
@@ -245,6 +372,36 @@ PUBLIC_API gchar *mib_client_app_generate_signed_http_request(
 	MIBClientApp *app, MIBAccount *account, MIBPopParams *pop_params);
 
 /**
+ * \brief Generate a signed HTTP request (async)
+ *
+ * Asynchronous variant of \ref mib_client_app_generate_signed_http_request.
+ *
+ * \dbusacall{generateSignedHttpRequest}
+ *
+ * \param app client app object
+ * \param account mib account reference
+ * \param pop_params PoP parameters
+ * \param callback a GAsyncReadyCallback to call when the request is done
+ * \param user_data user data to pass to the callback
+ */
+PUBLIC_API void mib_client_app_generate_signed_http_request_async(
+	MIBClientApp *app, MIBAccount *account, MIBPopParams *pop_params,
+	GAsyncReadyCallback callback, gpointer user_data);
+
+/**
+ * \brief Finish an async signed HTTP request generation
+ *
+ * The user is responsible for freeing the string with \c g_free .
+ *
+ * \param app client app object
+ * \param result the GAsyncResult passed to the callback
+ * \param error return location for a GError or NULL
+ * \return access token (must be freed with g_free()) or NULL on error
+ */
+PUBLIC_API gchar *mib_client_app_generate_signed_http_request_finish(
+	MIBClientApp *app, GAsyncResult *result, GError **error);
+
+/**
  * \brief Signout the account and clear linked token cache
  *
  * \dbuscall{removeAccount}
@@ -255,6 +412,35 @@ PUBLIC_API gchar *mib_client_app_generate_signed_http_request(
  */
 PUBLIC_API int mib_client_app_remove_account(MIBClientApp *app,
 											 MIBAccount *account);
+
+/**
+ * \brief Signout the account and clear linked token cache (async)
+ *
+ * Asynchronous variant of \ref mib_client_app_remove_account.
+ *
+ * \dbusacall{removeAccount}
+ *
+ * \param app client app object
+ * \param account mib account reference
+ * \param callback a GAsyncReadyCallback to call when the request is done
+ * \param user_data user data to pass to the callback
+ */
+PUBLIC_API void
+mib_client_app_remove_account_async(MIBClientApp *app, MIBAccount *account,
+									GAsyncReadyCallback callback,
+									gpointer user_data);
+
+/**
+ * \brief Finish an async remove account operation
+ *
+ * \param app client app object
+ * \param result the GAsyncResult passed to the callback
+ * \param error return location for a GError or NULL
+ * \return 0 on success, -1 on error
+ */
+PUBLIC_API int mib_client_app_remove_account_finish(MIBClientApp *app,
+													GAsyncResult *result,
+													GError **error);
 
 G_END_DECLS
 

--- a/include/mib-client-app.h
+++ b/include/mib-client-app.h
@@ -303,6 +303,47 @@ PUBLIC_API MIBPrt *mib_client_app_acquire_token_interactive(
 	const gchar *claims_challenge, MIBPopParams *auth_scheme);
 
 /**
+ * \brief Acquire a token with user interaction (async)
+ *
+ * Asynchronous variant of \ref mib_client_app_acquire_token_interactive.
+ * Internally, a silent token acquire is attempted first (unless
+ * \ref mib_client_app_set_enforce_interactive is set). If that fails,
+ * the interactive acquire is performed.
+ *
+ * \dbusacall{acquireTokenInteractively}
+ * \dbusacall{getAccounts}
+ * \dbusacall{acquireTokenSilently} (if interactive is not enforced)
+ *
+ * \param app client app object
+ * \param scopes list of scopes (\c gchar* entries)
+ * \param prompt what the user should be asked
+ * \param login_hint Identifier of the user. Generally a User Principal Name (UPN) (or NULL)
+ * \param domain_hint Not Implemented (yet). Set to NULL
+ * \param claims_challenge claims challenge or NULL
+ * \param auth_scheme PoP parameters or NULL
+ * \param callback a GAsyncReadyCallback to call when the request is done
+ * \param user_data user data to pass to the callback
+ */
+PUBLIC_API void mib_client_app_acquire_token_interactive_async(
+	MIBClientApp *app, GSList *scopes, enum MIB_PROMPT prompt,
+	const gchar *login_hint, const gchar *domain_hint,
+	const gchar *claims_challenge, MIBPopParams *auth_scheme,
+	GAsyncReadyCallback callback, gpointer user_data);
+
+/**
+ * \brief Finish an async interactive token acquisition
+ *
+ * The user is responsible for freeing the object with \c g_object_unref .
+ *
+ * \param app client app object
+ * \param result the GAsyncResult passed to the callback
+ * \param error return location for a GError or NULL
+ * \return PRT token struct or NULL on error
+ */
+PUBLIC_API MIBPrt *mib_client_app_acquire_token_interactive_finish(
+	MIBClientApp *app, GAsyncResult *result, GError **error);
+
+/**
  * \brief Acquire a PRT SSO cookie
  *
  * This function acquires a PRT SSO cookie for the given account, SSO URL and

--- a/meson.build
+++ b/meson.build
@@ -148,3 +148,7 @@ endif
 if get_option('examples')
   subdir('examples')
 endif
+
+if get_option('tests')
+  subdir('tests')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,6 +8,10 @@ option('examples',
        type: 'boolean',
        value: false,
        description: 'Build the examples [default=false]')
+option('tests',
+       type: 'boolean',
+       value: true,
+       description: 'Build the tests [default=true]')
 option('libjwt',
        description: 'Enable code that depends on libjwt',
        type: 'feature',

--- a/src/mib-client-app.c
+++ b/src/mib-client-app.c
@@ -366,11 +366,10 @@ gchar *mib_client_app_get_linux_broker_version(MIBClientApp *app,
 }
 
 static JsonObject *
-prepare_prt_auth_params(MIBClientApp *app, JsonObject *account,
-						JsonArray *scopes, const gchar *claims_challenge,
-						JsonObject *auth_scheme, const gchar *renew_token,
-						JsonObject *extra_params, const gchar *sso_url,
-						enum AuthorizationType auth_type)
+prepare_prt_auth_params(MIBClientApp *app, MIBAccount *account, GSList *scopes,
+						const gchar *claims_challenge, MIBPopParams *pop_params,
+						const gchar *renew_token, JsonObject *extra_params,
+						const gchar *sso_url, enum AuthorizationType auth_type)
 {
 	// {
 	//  'accessTokenToRenew': renew_token,
@@ -384,11 +383,17 @@ prepare_prt_auth_params(MIBClientApp *app, JsonObject *account,
 	//  'username': account['username'],
 	//  'ssoUrl': sso_url,
 	// }
+
+	JsonArray *scopes_json = mib_scopes_to_json(scopes);
+	JsonObject *account_json = mib_account_to_json(account);
+
 	JsonNode *account_node = json_node_new(JSON_NODE_OBJECT);
-	json_node_set_object(account_node, account);
+	json_node_set_object(account_node, account_json);
+	json_object_unref(account_json);
 	JsonNode *scopes_node = json_node_new(JSON_NODE_ARRAY);
-	json_node_set_array(scopes_node, scopes);
-	const gchar *username = json_object_get_string_member(account, "username");
+	json_node_set_array(scopes_node, scopes_json);
+	json_array_unref(scopes_json);
+	const gchar *username = mib_account_get_username(account);
 
 	JsonBuilder *builder = json_builder_new();
 	json_builder_begin_object(builder);
@@ -408,9 +413,11 @@ prepare_prt_auth_params(MIBClientApp *app, JsonObject *account,
 		json_builder_set_member_name(builder, "decodedClaims");
 		json_builder_add_string_value(builder, claims_challenge);
 	}
-	if (auth_scheme) {
+	if (pop_params) {
+		JsonObject *auth_scheme = mib_pop_params_to_json(pop_params);
 		JsonNode *auth_scheme_node = json_node_new(JSON_NODE_OBJECT);
 		json_node_set_object(auth_scheme_node, auth_scheme);
+		json_object_unref(auth_scheme);
 		json_builder_set_member_name(builder, "popParams");
 		json_builder_add_value(builder, auth_scheme_node);
 	}
@@ -441,17 +448,13 @@ prepare_prt_auth_params(MIBClientApp *app, JsonObject *account,
 	return auth_params;
 }
 
-static JsonObject *
-mib_acquire_token_silent_raw(MIBClientApp *app, JsonObject *account,
-							 JsonArray *scopes, const gchar *claims_challenge,
-							 JsonObject *auth_scheme, const gchar *renew_token)
+static gchar *acquire_token_silent_prepare_request(
+	MIBClientApp *app, MIBAccount *account, GSList *scopes,
+	const gchar *claims_challenge, MIBPopParams *pop_params,
+	const gchar *renew_token)
 {
-	GError *error = NULL;
-	gchar *response;
-	gboolean ok;
-	JsonObject *token;
 	JsonObject *auth_params = prepare_prt_auth_params(
-		app, account, scopes, claims_challenge, auth_scheme, renew_token, NULL,
+		app, account, scopes, claims_challenge, pop_params, renew_token, NULL,
 		NULL, AT_CACHED_REFRESH_TOKEN);
 	JsonNode *auth_params_node = json_node_new(JSON_NODE_OBJECT);
 	json_node_set_object(auth_params_node, auth_params);
@@ -459,10 +462,34 @@ mib_acquire_token_silent_raw(MIBClientApp *app, JsonObject *account,
 
 	JsonObject *params_obj = json_object_new();
 	json_object_set_member(params_obj, "authParameters", auth_params_node);
-	debug_print_json_object("mib_acquire_token_silent_raw", "request",
+	debug_print_json_object("mib_acquire_token_silent", "request",
 							params_obj);
 	gchar *data = json_object_to_string(params_obj);
 	json_object_unref(params_obj);
+
+	return data;
+}
+
+MIBPrt *mib_client_app_acquire_token_silent(MIBClientApp *app,
+											MIBAccount *account, GSList *scopes,
+											const gchar *claims_challenge,
+											MIBPopParams *auth_scheme,
+											const gchar *id_token)
+{
+	GError *error = NULL;
+	gchar *response;
+	gboolean ok;
+	JsonObject *token_json;
+
+	g_assert(app);
+	g_assert(account);
+	g_assert(scopes);
+
+	gchar *data = acquire_token_silent_prepare_request(
+		app, account, scopes, claims_challenge, auth_scheme, id_token);
+	if (!data) {
+		return NULL;
+	}
 
 	ok = mib_dbus_identity_broker1_call_acquire_token_silently_sync(
 		mib_client_app_get_broker(app), MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
@@ -474,59 +501,27 @@ mib_acquire_token_silent_raw(MIBClientApp *app, JsonObject *account,
 		g_error_free(error);
 		return NULL;
 	}
-	token = json_object_from_string(response);
+	token_json = json_object_from_string(response);
 	g_free(response);
-	if (!token) {
+	if (!token_json) {
 		g_warning("could not parse token response");
 		return NULL;
 	}
-	debug_print_json_object("mib_acquire_token_silent_raw", "response", token);
-	return token;
-}
+	debug_print_json_object("mib_acquire_token_silent", "response", token_json);
 
-MIBPrt *mib_client_app_acquire_token_silent(MIBClientApp *app,
-											MIBAccount *account, GSList *scopes,
-											const gchar *claims_challenge,
-											MIBPopParams *auth_scheme,
-											const gchar *id_token)
-{
-	g_assert(app);
-	g_assert(account);
-	g_assert(scopes);
-
-	JsonObject *account_json = mib_account_to_json(account);
-	JsonArray *scopes_array = mib_scopes_to_json(scopes);
-	JsonObject *pop_params = auth_scheme ? mib_pop_params_to_json(auth_scheme) :
-										   NULL;
-	JsonObject *token_json =
-		mib_acquire_token_silent_raw(app, account_json, scopes_array,
-									 claims_challenge, pop_params, id_token);
-	json_object_unref(account_json);
-	json_array_unref(scopes_array);
-	if (pop_params) {
-		json_object_unref(pop_params);
-	}
-	if (!token_json) {
-		return NULL;
-	}
 	MIBPrt *token = mib_prt_from_json(token_json, account);
 	json_object_unref(token_json);
 	return token;
 }
 
-static JsonObject *mib_acquire_token_interactive_raw(
-	MIBClientApp *app, JsonArray *scopes, enum MIB_PROMPT prompt,
-	JsonObject *account, MIB_ARG_UNUSED const gchar *domain_hint,
-	const gchar *claims_challenge, JsonObject *auth_scheme,
+static gchar *acquire_token_interactive_prepare_request(
+	MIBClientApp *app, GSList *scopes, enum MIB_PROMPT prompt,
+	MIBAccount *account, MIB_ARG_UNUSED const gchar *domain_hint,
+	const gchar *claims_challenge, MIBPopParams *pop_params,
 	JsonObject *extra_params)
 {
-	GError *error = NULL;
-	gchar *response;
-	gboolean ok;
-	JsonObject *token;
-
 	JsonObject *auth_params = prepare_prt_auth_params(
-		app, account, scopes, claims_challenge, auth_scheme, NULL, extra_params,
+		app, account, scopes, claims_challenge, pop_params, NULL, extra_params,
 		NULL, AT_INTERACTIVE);
 
 	/* TODO: check if this is the correct key */
@@ -547,131 +542,154 @@ static JsonObject *mib_acquire_token_interactive_raw(
 	json_object_unref(auth_params);
 
 	json_object_set_member(params_obj, "authParameters", auth_params_node);
-	debug_print_json_object("mib_acquire_token_interactive_raw", "request",
+	debug_print_json_object("mib_acquire_token_interactive", "request",
 							params_obj);
 	gchar *data = json_object_to_string(params_obj);
 	json_object_unref(params_obj);
+	return data;
+}
 
-	/* disable dbus timeout before call and restore after as user input is needed */
-	mibdbusIdentityBroker1 *gd_proxy = mib_client_app_get_broker(app);
-	g_dbus_proxy_set_default_timeout((GDBusProxy *)gd_proxy, G_MAXINT);
-	ok = mib_dbus_identity_broker1_call_acquire_token_interactively_sync(
-		gd_proxy, MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
-		mib_client_app_get_correlation_id(app), data, &response,
-		mib_client_app_get_cancellable(app), &error);
-	g_dbus_proxy_set_default_timeout((GDBusProxy *)gd_proxy, -1);
-
-	g_free(data);
-	if (!ok) {
-		g_warning("could not acquire token: %s", error->message);
-		g_error_free(error);
-		return NULL;
-	}
-	token = json_object_from_string(response);
-	g_free(response);
-	if (!token) {
+static MIBPrt *acquire_token_interactive_process_response(const gchar *response,
+														  MIBAccount *account)
+{
+	MIBPrt *token = NULL;
+	JsonObject *token_json = json_object_from_string(response);
+	if (!token_json) {
 		g_warning("could not parse token response");
 		return NULL;
 	}
-	debug_print_json_object("mib_acquire_token_interactive_raw", "response",
-							token);
+	debug_print_json_object("mib_acquire_token_interactive", "response",
+							token_json);
+	token = mib_prt_from_json(token_json, account);
+	json_object_unref(token_json);
+
 	return token;
 }
 
 MIBPrt *mib_client_app_acquire_token_interactive(
 	MIBClientApp *app, GSList *scopes, enum MIB_PROMPT prompt,
 	const gchar *login_hint, const gchar *domain_hint,
-	const gchar *claims_challenge, MIBPopParams *auth_scheme)
+	const gchar *claims_challenge, MIBPopParams *pop_params)
 {
+	MIBPrt *token = NULL;
+	gchar *response = NULL;
+	GError *error = NULL;
+	gboolean ok;
+
 	g_assert(app);
 	g_assert(scopes);
 
-	MIBPrt *token = NULL;
-	JsonObject *token_json = NULL;
-	JsonObject *account_json = NULL;
-	MIBAccount *fallback_account =
-		mib_client_app_get_account_by_upn(app, login_hint);
-	if (!fallback_account) {
+	MIBAccount *account = mib_client_app_get_account_by_upn(app, login_hint);
+	if (!account) {
 		return NULL;
 	}
-	account_json = mib_account_to_json(fallback_account);
-
-	JsonArray *scopes_array = mib_scopes_to_json(scopes);
-	JsonObject *pop_params = auth_scheme ? mib_pop_params_to_json(auth_scheme) :
-										   NULL;
 
 	/* first try silent, on error try interactive */
 	if (!mib_client_app_get_enforce_interactive(app)) {
-		token_json =
-			mib_acquire_token_silent_raw(app, account_json, scopes_array,
-										 claims_challenge, pop_params, NULL);
-	}
-	if (token_json) {
-		token = mib_prt_from_json(token_json, fallback_account);
-		json_object_unref(token_json);
+		token = mib_client_app_acquire_token_silent(
+			app, account, scopes, claims_challenge, pop_params, NULL);
 	}
 	if (!token) {
-		token_json = mib_acquire_token_interactive_raw(
-			app, scopes_array, prompt, account_json, domain_hint,
-			claims_challenge, pop_params, NULL);
-		if (token_json) {
-			token = mib_prt_from_json(token_json, fallback_account);
-			json_object_unref(token_json);
+		gchar *data = acquire_token_interactive_prepare_request(
+			app, scopes, prompt, account, domain_hint, claims_challenge,
+			pop_params, NULL);
+
+		/* disable dbus timeout before call and restore after as user input is needed */
+		mibdbusIdentityBroker1 *gd_proxy = mib_client_app_get_broker(app);
+		g_dbus_proxy_set_default_timeout((GDBusProxy *)gd_proxy, G_MAXINT);
+		ok = mib_dbus_identity_broker1_call_acquire_token_interactively_sync(
+			gd_proxy, MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
+			mib_client_app_get_correlation_id(app), data, &response,
+			mib_client_app_get_cancellable(app), &error);
+		g_free(data);
+		g_dbus_proxy_set_default_timeout((GDBusProxy *)gd_proxy, -1);
+		if (!ok) {
+			g_warning("could not acquire token: %s", error->message);
+			g_error_free(error);
+			goto err;
 		}
+
+		token = acquire_token_interactive_process_response(response, account);
+		g_free(response);
 	}
-	json_object_unref(account_json);
-	json_array_unref(scopes_array);
-	if (pop_params) {
-		json_object_unref(pop_params);
-	}
-	g_clear_object(&fallback_account);
+err:
+	g_clear_object(&account);
 	return token;
 }
 
-static JsonObject *prepare_prt_sso_request_data(JsonObject *account,
-												JsonObject *auth_params,
-												const gchar *sso_url)
+static gchar *acquire_prt_sso_cookie_request_prepare(MIBClientApp *app,
+													 MIBAccount *account,
+													 GSList *scopes,
+													 const gchar *sso_url)
 {
 	// {
 	//  'account': account,
 	//  'authParameters': params,
 	//  'ssoUrl': sso_url
 	// }
+	gchar *data = NULL;
+
+	JsonObject *auth_params =
+		prepare_prt_auth_params(app, account, scopes, NULL, NULL, NULL, NULL,
+								sso_url, AT_PRT_SSO_COOKIE);
+	JsonObject *account_json = mib_account_to_json(account);
+
 	JsonObject *params_obj = json_object_new();
 	JsonNode *account_node = json_node_new(JSON_NODE_OBJECT);
-	json_node_set_object(account_node, account);
+	json_node_set_object(account_node, account_json);
+	json_object_unref(account_json);
 	JsonNode *auth_params_node = json_node_new(JSON_NODE_OBJECT);
 	json_node_set_object(auth_params_node, auth_params);
+	json_object_unref(auth_params);
 	JsonNode *sso_url_node = json_node_new(JSON_NODE_VALUE);
 	json_node_set_string(sso_url_node, sso_url);
 
 	json_object_set_member(params_obj, "account", account_node);
 	json_object_set_member(params_obj, "authParameters", auth_params_node);
 	json_object_set_member(params_obj, "ssoUrl", sso_url_node);
-	return params_obj;
+
+	debug_print_json_object("mib_acquire_prt_sso_cookie", "request",
+							params_obj);
+	data = json_object_to_string(params_obj);
+	json_object_unref(params_obj);
+
+	return data;
 }
 
-static JsonObject *mib_acquire_prt_sso_cookie_raw(MIBClientApp *app,
-												  JsonObject *account,
-												  const gchar *sso_url,
-												  JsonArray *scopes)
+static MIBPrtSsoCookie *
+acquire_prt_sso_cookie_process_response(const gchar *response)
 {
-	JsonObject *cookie;
+	MIBPrtSsoCookie *cookie = NULL;
+	JsonObject *cookie_json = json_object_from_string(response);
+	if (!cookie_json) {
+		g_warning("could not parse PRT SSO cookie response");
+		return NULL;
+	}
+	debug_print_json_object("mib_acquire_prt_sso_cookie", "response",
+							cookie_json);
+	cookie = mib_prt_sso_cookie_from_json(cookie_json);
+	json_object_unref(cookie_json);
+	return cookie;
+}
+
+MIBPrtSsoCookie *mib_client_app_acquire_prt_sso_cookie(MIBClientApp *app,
+													   MIBAccount *account,
+													   const gchar *sso_url,
+													   GSList *scopes)
+{
+	MIBPrtSsoCookie *cookie = NULL;
 	gchar *data;
 	GError *error = NULL;
 	gchar *response;
 	gboolean ok;
 
-	JsonObject *auth_params =
-		prepare_prt_auth_params(app, account, scopes, NULL, NULL, NULL, NULL,
-								sso_url, AT_PRT_SSO_COOKIE);
-	JsonObject *params =
-		prepare_prt_sso_request_data(account, auth_params, sso_url);
-	debug_print_json_object("mib_acquire_prt_sso_cookie_raw", "request",
-							params);
-	data = json_object_to_string(params);
-	json_object_unref(params);
-	json_object_unref(auth_params);
+	g_assert(app);
+	g_assert(account);
+	g_assert(sso_url);
+	g_assert(scopes);
+
+	data =
+		acquire_prt_sso_cookie_request_prepare(app, account, scopes, sso_url);
 
 	ok = mib_dbus_identity_broker1_call_acquire_prt_sso_cookie_sync(
 		mib_client_app_get_broker(app), MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
@@ -683,110 +701,91 @@ static JsonObject *mib_acquire_prt_sso_cookie_raw(MIBClientApp *app,
 		g_error_free(error);
 		return NULL;
 	}
-	cookie = json_object_from_string(response);
+	cookie = acquire_prt_sso_cookie_process_response(response);
 	g_free(response);
-	if (!cookie) {
-		g_warning("could not parse PRT SSO cookie response");
-		return NULL;
-	}
-	debug_print_json_object("mib_acquire_prt_sso_cookie_raw", "response",
-							cookie);
 	return cookie;
 }
 
-MIBPrtSsoCookie *mib_client_app_acquire_prt_sso_cookie(MIBClientApp *app,
-													   MIBAccount *account,
-													   const gchar *sso_url,
-													   GSList *scopes)
+static gchar *generate_signed_http_request_prepare_request(
+	MIBClientApp *app, MIBAccount *account, MIBPopParams *pop_params)
 {
-	g_assert(app);
-	g_assert(account);
-	g_assert(sso_url);
-	g_assert(scopes);
+	gchar *data = NULL;
+	const gchar *account_id = NULL;
+	JsonObject *pop_params_json = NULL;
+	JsonObject *params;
 
-	JsonObject *account_json = mib_account_to_json(account);
-	JsonArray *scopes_array = mib_scopes_to_json(scopes);
-	JsonObject *cookie_json = mib_acquire_prt_sso_cookie_raw(
-		app, account_json, sso_url, scopes_array);
-	json_object_unref(account_json);
-	json_array_unref(scopes_array);
-	if (!cookie_json) {
-		return NULL;
+	if (pop_params) {
+		pop_params_json = mib_pop_params_to_json(pop_params);
+	} else {
+		pop_params_json = json_object_new();
 	}
-	MIBPrtSsoCookie *cookie = mib_prt_sso_cookie_from_json(cookie_json);
-	json_object_unref(cookie_json);
-	return cookie;
-}
+	account_id = mib_account_get_home_account_id(account);
+	json_object_set_string_member(pop_params_json, "homeAccountId", account_id);
 
-static JsonObject *mib_generate_signed_http_request_raw(MIBClientApp *app,
-														JsonObject *pop_params)
-{
-	GError *error = NULL;
-	gboolean ok;
-	gchar *response;
-	JsonObject *params = json_object_new();
+	params = json_object_new();
 	json_object_set_string_member(params, "clientId",
 								  mib_client_app_get_client_id(app));
-	json_object_ref(pop_params);
-	json_object_set_object_member(params, "popParams", pop_params);
-	debug_print_json_object("mib_generate_signed_http_request_raw", "request",
+	json_object_set_object_member(params, "popParams", pop_params_json);
+
+	debug_print_json_object("mib_generate_signed_http_request", "request",
 							params);
-	gchar *params_data = json_object_to_string(params);
+
+	data = json_object_to_string(params);
 	json_object_unref(params);
+	return data;
+}
 
-	ok = mib_dbus_identity_broker1_call_generate_signed_http_request_sync(
-		mib_client_app_get_broker(app), MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
-		mib_client_app_get_correlation_id(app), params_data, &response,
-		mib_client_app_get_cancellable(app), &error);
-
-	g_free(params_data);
-	if (!ok) {
-		g_warning("could not generate signed HTTP request: %s", error->message);
-		g_error_free(error);
-		return NULL;
-	}
-	JsonObject *token = json_object_from_string(response);
-	g_free(response);
-	if (!token) {
+static gchar *
+generate_signed_http_request_process_response(const gchar *response)
+{
+	gchar *access_token = NULL;
+	JsonObject *token_json = json_object_from_string(response);
+	if (!token_json) {
 		g_warning("could not parse signed HTTP request response");
 		return NULL;
 	}
-	debug_print_json_object("mib_generate_signed_http_request_raw", "response",
-							token);
-	return token;
+	debug_print_json_object("mib_generate_signed_http_request", "response",
+							token_json);
+
+	if (!json_object_has_member(token_json, "signedHttpRequest")) {
+		g_warning("response json is missing 'signedHttpRequest'");
+		goto err;
+	}
+	access_token = g_strdup(
+		json_object_get_string_member(token_json, "signedHttpRequest"));
+err:
+	json_object_unref(token_json);
+	return access_token;
 }
 
 gchar *mib_client_app_generate_signed_http_request(MIBClientApp *app,
 												   MIBAccount *account,
 												   MIBPopParams *pop_params)
 {
-	JsonObject *params_json;
+	GError *error = NULL;
+	gboolean ok;
+	gchar *response;
+	gchar *data = NULL;
 	gchar *access_token = NULL;
-	const gchar *account_id = NULL;
 
 	g_assert(app);
 	g_assert(account);
 
-	if (pop_params) {
-		params_json = mib_pop_params_to_json(pop_params);
-	} else {
-		params_json = json_object_new();
-	}
-	account_id = mib_account_get_home_account_id(account);
-	json_object_set_string_member(params_json, "homeAccountId", account_id);
-	JsonObject *token = mib_generate_signed_http_request_raw(app, params_json);
-	json_object_unref(params_json);
-	if (!token) {
+	data =
+		generate_signed_http_request_prepare_request(app, account, pop_params);
+
+	ok = mib_dbus_identity_broker1_call_generate_signed_http_request_sync(
+		mib_client_app_get_broker(app), MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
+		mib_client_app_get_correlation_id(app), data, &response,
+		mib_client_app_get_cancellable(app), &error);
+	g_free(data);
+	if (!ok) {
+		g_warning("could not generate signed HTTP request: %s", error->message);
+		g_error_free(error);
 		return NULL;
 	}
-	if (!json_object_has_member(token, "signedHttpRequest")) {
-		g_warning("response json is missing 'signedHttpRequest'");
-		goto err;
-	}
-	access_token =
-		g_strdup(json_object_get_string_member(token, "signedHttpRequest"));
-err:
-	json_object_unref(token);
+	access_token = generate_signed_http_request_process_response(response);
+	g_free(response);
 	return access_token;
 }
 

--- a/src/mib-client-app.c
+++ b/src/mib-client-app.c
@@ -218,6 +218,56 @@ GSList *mib_client_app_get_accounts(MIBClientApp *app)
 	return accounts;
 }
 
+static void get_accounts_async_cb(GObject *source_object, GAsyncResult *res,
+								  gpointer user_data)
+{
+	GTask *task = G_TASK(user_data);
+	mibdbusIdentityBroker1 *proxy = MIB_DBUS_IDENTITY_BROKER1(source_object);
+	GError *error = NULL;
+	gchar *response = NULL;
+	gboolean ok;
+
+	ok = mib_dbus_identity_broker1_call_get_accounts_finish(proxy, &response,
+															res, &error);
+	if (!ok) {
+		g_task_return_error(task, error);
+	} else {
+		GSList *accounts = get_accounts_process_response(response);
+		g_free(response);
+		g_task_return_pointer(task, accounts, NULL);
+	}
+	g_object_unref(task);
+}
+
+void mib_client_app_get_accounts_async(MIBClientApp *app,
+									   GAsyncReadyCallback callback,
+									   gpointer user_data)
+{
+	GTask *task;
+	gchar *data;
+
+	g_assert(app);
+
+	task = g_task_new(app, mib_client_app_get_cancellable(app), callback,
+					  user_data);
+	data = get_accounts_prepare_request(app);
+
+	mib_dbus_identity_broker1_call_get_accounts(
+		mib_client_app_get_broker(app), MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
+		mib_client_app_get_correlation_id(app), data,
+		mib_client_app_get_cancellable(app), get_accounts_async_cb, task);
+	g_free(data);
+}
+
+GSList *mib_client_app_get_accounts_finish(MIBClientApp *app,
+										   GAsyncResult *result, GError **error)
+{
+	g_assert(app);
+	g_assert(g_task_is_valid(result, app));
+
+	return g_task_propagate_pointer(G_TASK(result), error);
+}
+
 MIBAccount *mib_client_app_get_account_by_upn(MIBClientApp *app,
 											  const gchar *upn)
 {
@@ -349,6 +399,65 @@ gchar *mib_client_app_get_linux_broker_version(MIBClientApp *app,
 	version = linux_broker_version_process_response(response);
 	g_free(response);
 	return version;
+}
+
+static void get_linux_broker_version_async_cb(GObject *source_object,
+											  GAsyncResult *res,
+											  gpointer user_data)
+{
+	GTask *task = G_TASK(user_data);
+	mibdbusIdentityBroker1 *proxy = MIB_DBUS_IDENTITY_BROKER1(source_object);
+	GError *error = NULL;
+	gchar *response = NULL;
+	gboolean ok;
+
+	ok = mib_dbus_identity_broker1_call_get_linux_broker_version_finish(
+		proxy, &response, res, &error);
+	if (!ok) {
+		g_task_return_error(task, error);
+	} else {
+		gchar *version = linux_broker_version_process_response(response);
+		g_free(response);
+		if (version) {
+			g_task_return_pointer(task, version, g_free);
+		} else {
+			g_task_return_new_error(task, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+									"could not parse broker version response");
+		}
+	}
+	g_object_unref(task);
+}
+
+void mib_client_app_get_linux_broker_version_async(
+	MIBClientApp *app, const gchar *msal_cpp_version,
+	GAsyncReadyCallback callback, gpointer user_data)
+{
+	GTask *task;
+	gchar *params_data;
+
+	g_assert(app);
+	g_assert(msal_cpp_version);
+
+	task = g_task_new(app, mib_client_app_get_cancellable(app), callback,
+					  user_data);
+	params_data = linux_broker_version_prepare_request(app, msal_cpp_version);
+
+	mib_dbus_identity_broker1_call_get_linux_broker_version(
+		mib_client_app_get_broker(app), MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
+		mib_client_app_get_correlation_id(app), params_data,
+		mib_client_app_get_cancellable(app), get_linux_broker_version_async_cb,
+		task);
+	g_free(params_data);
+}
+
+gchar *mib_client_app_get_linux_broker_version_finish(MIBClientApp *app,
+													  GAsyncResult *result,
+													  GError **error)
+{
+	g_assert(app);
+	g_assert(g_task_is_valid(result, app));
+
+	return g_task_propagate_pointer(G_TASK(result), error);
 }
 
 static JsonObject *
@@ -497,6 +606,80 @@ MIBPrt *mib_client_app_acquire_token_silent(MIBClientApp *app,
 	MIBPrt *token = mib_prt_from_json(token_json, account);
 	json_object_unref(token_json);
 	return token;
+}
+
+static void acquire_token_silent_async_cb(GObject *source_object,
+										  GAsyncResult *res, gpointer user_data)
+{
+	GTask *task = G_TASK(user_data);
+	mibdbusIdentityBroker1 *proxy = MIB_DBUS_IDENTITY_BROKER1(source_object);
+	MIBAccount *account = g_task_get_task_data(task);
+	GError *error = NULL;
+	gchar *response = NULL;
+	gboolean ok;
+
+	ok = mib_dbus_identity_broker1_call_acquire_token_silently_finish(
+		proxy, &response, res, &error);
+	if (!ok) {
+		g_task_return_error(task, error);
+	} else {
+		JsonObject *token_json = json_object_from_string(response);
+		g_free(response);
+		if (!token_json) {
+			g_task_return_new_error(task, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+									"could not parse token response");
+		} else {
+			debug_print_json_object("mib_acquire_token_silent", "response",
+									token_json);
+			MIBPrt *token = mib_prt_from_json(token_json, account);
+			json_object_unref(token_json);
+			if (token) {
+				g_task_return_pointer(task, token, g_object_unref);
+			} else {
+				g_task_return_new_error(task, G_IO_ERROR,
+										G_IO_ERROR_INVALID_DATA,
+										"could not parse token from response");
+			}
+		}
+	}
+	g_object_unref(task);
+}
+
+void mib_client_app_acquire_token_silent_async(
+	MIBClientApp *app, MIBAccount *account, GSList *scopes,
+	const gchar *claims_challenge, MIBPopParams *auth_scheme,
+	const gchar *id_token, GAsyncReadyCallback callback, gpointer user_data)
+{
+	GTask *task;
+	gchar *data;
+
+	g_assert(app);
+	g_assert(account);
+	g_assert(scopes);
+
+	task = g_task_new(app, mib_client_app_get_cancellable(app), callback,
+					  user_data);
+	g_task_set_task_data(task, g_object_ref(account), g_object_unref);
+
+	data = acquire_token_silent_prepare_request(
+		app, account, scopes, claims_challenge, auth_scheme, id_token);
+
+	mib_dbus_identity_broker1_call_acquire_token_silently(
+		mib_client_app_get_broker(app), MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
+		mib_client_app_get_correlation_id(app), data,
+		mib_client_app_get_cancellable(app), acquire_token_silent_async_cb,
+		task);
+	g_free(data);
+}
+
+MIBPrt *mib_client_app_acquire_token_silent_finish(MIBClientApp *app,
+												   GAsyncResult *result,
+												   GError **error)
+{
+	g_assert(app);
+	g_assert(g_task_is_valid(result, app));
+
+	return g_task_propagate_pointer(G_TASK(result), error);
 }
 
 static gchar *acquire_token_interactive_prepare_request(
@@ -691,6 +874,69 @@ MIBPrtSsoCookie *mib_client_app_acquire_prt_sso_cookie(MIBClientApp *app,
 	return cookie;
 }
 
+static void acquire_prt_sso_cookie_async_cb(GObject *source_object,
+											GAsyncResult *res,
+											gpointer user_data)
+{
+	GTask *task = G_TASK(user_data);
+	mibdbusIdentityBroker1 *proxy = MIB_DBUS_IDENTITY_BROKER1(source_object);
+	GError *error = NULL;
+	gchar *response = NULL;
+	gboolean ok;
+
+	ok = mib_dbus_identity_broker1_call_acquire_prt_sso_cookie_finish(
+		proxy, &response, res, &error);
+	if (!ok) {
+		g_task_return_error(task, error);
+	} else {
+		MIBPrtSsoCookie *cookie =
+			acquire_prt_sso_cookie_process_response(response);
+		g_free(response);
+		if (cookie) {
+			g_task_return_pointer(task, cookie, g_object_unref);
+		} else {
+			g_task_return_new_error(task, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+									"could not parse PRT SSO cookie response");
+		}
+	}
+	g_object_unref(task);
+}
+
+void mib_client_app_acquire_prt_sso_cookie_async(
+	MIBClientApp *app, MIBAccount *account, const gchar *sso_url,
+	GSList *scopes, GAsyncReadyCallback callback, gpointer user_data)
+{
+	GTask *task;
+	gchar *data;
+
+	g_assert(app);
+	g_assert(account);
+	g_assert(sso_url);
+	g_assert(scopes);
+
+	task = g_task_new(app, mib_client_app_get_cancellable(app), callback,
+					  user_data);
+
+	data =
+		acquire_prt_sso_cookie_request_prepare(app, account, scopes, sso_url);
+
+	mib_dbus_identity_broker1_call_acquire_prt_sso_cookie(
+		mib_client_app_get_broker(app), MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
+		mib_client_app_get_correlation_id(app), data,
+		mib_client_app_get_cancellable(app), acquire_prt_sso_cookie_async_cb,
+		task);
+	g_free(data);
+}
+
+MIBPrtSsoCookie *mib_client_app_acquire_prt_sso_cookie_finish(
+	MIBClientApp *app, GAsyncResult *result, GError **error)
+{
+	g_assert(app);
+	g_assert(g_task_is_valid(result, app));
+
+	return g_task_propagate_pointer(G_TASK(result), error);
+}
+
 static gchar *generate_signed_http_request_prepare_request(
 	MIBClientApp *app, MIBAccount *account, MIBPopParams *pop_params)
 {
@@ -774,6 +1020,69 @@ gchar *mib_client_app_generate_signed_http_request(MIBClientApp *app,
 	return access_token;
 }
 
+static void generate_signed_http_request_async_cb(GObject *source_object,
+												  GAsyncResult *res,
+												  gpointer user_data)
+{
+	GTask *task = G_TASK(user_data);
+	mibdbusIdentityBroker1 *proxy = MIB_DBUS_IDENTITY_BROKER1(source_object);
+	GError *error = NULL;
+	gchar *response = NULL;
+	gboolean ok;
+
+	ok = mib_dbus_identity_broker1_call_generate_signed_http_request_finish(
+		proxy, &response, res, &error);
+	if (!ok) {
+		g_task_return_error(task, error);
+	} else {
+		gchar *access_token =
+			generate_signed_http_request_process_response(response);
+		g_free(response);
+		if (access_token) {
+			g_task_return_pointer(task, access_token, g_free);
+		} else {
+			g_task_return_new_error(
+				task, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+				"could not parse signed HTTP request response");
+		}
+	}
+	g_object_unref(task);
+}
+
+void mib_client_app_generate_signed_http_request_async(
+	MIBClientApp *app, MIBAccount *account, MIBPopParams *pop_params,
+	GAsyncReadyCallback callback, gpointer user_data)
+{
+	GTask *task;
+	gchar *data;
+
+	g_assert(app);
+	g_assert(account);
+
+	task = g_task_new(app, mib_client_app_get_cancellable(app), callback,
+					  user_data);
+
+	data =
+		generate_signed_http_request_prepare_request(app, account, pop_params);
+
+	mib_dbus_identity_broker1_call_generate_signed_http_request(
+		mib_client_app_get_broker(app), MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
+		mib_client_app_get_correlation_id(app), data,
+		mib_client_app_get_cancellable(app),
+		generate_signed_http_request_async_cb, task);
+	g_free(data);
+}
+
+gchar *mib_client_app_generate_signed_http_request_finish(MIBClientApp *app,
+														  GAsyncResult *result,
+														  GError **error)
+{
+	g_assert(app);
+	g_assert(g_task_is_valid(result, app));
+
+	return g_task_propagate_pointer(G_TASK(result), error);
+}
+
 static gchar *remove_account_prepare_request(MIBClientApp *app,
 											 MIBAccount *account)
 {
@@ -822,4 +1131,57 @@ int mib_client_app_remove_account(MIBClientApp *app, MIBAccount *account)
 	remove_account_process_response(response);
 	g_free(response);
 	return 0;
+}
+
+static void remove_account_async_cb(GObject *source_object, GAsyncResult *res,
+									gpointer user_data)
+{
+	GTask *task = G_TASK(user_data);
+	mibdbusIdentityBroker1 *proxy = MIB_DBUS_IDENTITY_BROKER1(source_object);
+	GError *error = NULL;
+	gchar *response = NULL;
+	gboolean ok;
+
+	ok = mib_dbus_identity_broker1_call_remove_account_finish(proxy, &response,
+															  res, &error);
+	if (!ok) {
+		g_task_return_error(task, error);
+	} else {
+		remove_account_process_response(response);
+		g_free(response);
+		g_task_return_int(task, 0);
+	}
+	g_object_unref(task);
+}
+
+void mib_client_app_remove_account_async(MIBClientApp *app, MIBAccount *account,
+										 GAsyncReadyCallback callback,
+										 gpointer user_data)
+{
+	GTask *task;
+	gchar *data;
+
+	g_assert(app);
+	g_assert(account);
+
+	task = g_task_new(app, mib_client_app_get_cancellable(app), callback,
+					  user_data);
+
+	data = remove_account_prepare_request(app, account);
+
+	mib_dbus_identity_broker1_call_remove_account(
+		mib_client_app_get_broker(app), MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
+		mib_client_app_get_correlation_id(app), data,
+		mib_client_app_get_cancellable(app), remove_account_async_cb, task);
+	g_free(data);
+}
+
+int mib_client_app_remove_account_finish(MIBClientApp *app,
+										 GAsyncResult *result, GError **error)
+{
+	g_assert(app);
+	g_assert(g_task_is_valid(result, app));
+
+	gboolean ok = g_task_propagate_int(G_TASK(result), error) == 0;
+	return ok ? 0 : -1;
 }

--- a/src/mib-client-app.c
+++ b/src/mib-client-app.c
@@ -56,6 +56,28 @@ struct _MIBClientApp {
 };
 G_DEFINE_TYPE(MIBClientApp, mib_client_app, G_TYPE_OBJECT)
 
+typedef struct {
+	GSList *scopes;
+	enum MIB_PROMPT prompt;
+	gchar *domain_hint;
+	gchar *claims_challenge;
+	MIBPopParams *pop_params;
+	gchar *login_hint;
+	MIBAccount *account;
+} InteractiveAsyncCtx;
+
+static void interactive_async_ctx_free(gpointer data)
+{
+	InteractiveAsyncCtx *ctx = data;
+	g_free(ctx->login_hint);
+	g_free(ctx->domain_hint);
+	g_free(ctx->claims_challenge);
+	g_clear_object(&ctx->pop_params);
+	g_clear_object(&ctx->account);
+	g_slist_free_full(ctx->scopes, g_free);
+	g_free(ctx);
+}
+
 static void mib_client_app_finalize(GObject *gobject)
 {
 	MIBClientApp *priv = MIB_CLIENT_APP(gobject);
@@ -783,6 +805,191 @@ MIBPrt *mib_client_app_acquire_token_interactive(
 err:
 	g_clear_object(&account);
 	return token;
+}
+
+static void acquire_token_interactive_async_cb(GObject *source_object,
+											   GAsyncResult *res,
+											   gpointer user_data)
+{
+	GTask *task = G_TASK(user_data);
+	mibdbusIdentityBroker1 *proxy = MIB_DBUS_IDENTITY_BROKER1(source_object);
+	InteractiveAsyncCtx *ctx = g_task_get_task_data(task);
+	GError *error = NULL;
+	gchar *response = NULL;
+	gboolean ok;
+
+	/* restore default dbus timeout */
+	g_dbus_proxy_set_default_timeout((GDBusProxy *)proxy, -1);
+
+	ok = mib_dbus_identity_broker1_call_acquire_token_interactively_finish(
+		proxy, &response, res, &error);
+	if (!ok) {
+		g_task_return_error(task, error);
+	} else {
+		MIBPrt *token =
+			acquire_token_interactive_process_response(response, ctx->account);
+		g_free(response);
+		if (token) {
+			g_task_return_pointer(task, token, g_object_unref);
+		} else {
+			g_task_return_new_error(
+				task, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+				"could not parse interactive token response");
+		}
+	}
+	g_object_unref(task);
+}
+
+static void interactive_async_start_interactive(GTask *task)
+{
+	InteractiveAsyncCtx *ctx = g_task_get_task_data(task);
+	MIBClientApp *app = g_task_get_source_object(task);
+
+	gchar *data = acquire_token_interactive_prepare_request(
+		app, ctx->scopes, ctx->prompt, ctx->account, ctx->domain_hint,
+		ctx->claims_challenge, ctx->pop_params, NULL);
+
+	/* disable dbus timeout as user input is needed */
+	mibdbusIdentityBroker1 *gd_proxy = mib_client_app_get_broker(app);
+	g_dbus_proxy_set_default_timeout((GDBusProxy *)gd_proxy, G_MAXINT);
+
+	mib_dbus_identity_broker1_call_acquire_token_interactively(
+		gd_proxy, MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
+		mib_client_app_get_correlation_id(app), data,
+		mib_client_app_get_cancellable(app), acquire_token_interactive_async_cb,
+		task);
+	g_free(data);
+}
+
+static void interactive_silent_cb(GObject *source_object, GAsyncResult *res,
+								  gpointer user_data)
+{
+	GTask *task = G_TASK(user_data);
+	mibdbusIdentityBroker1 *proxy = MIB_DBUS_IDENTITY_BROKER1(source_object);
+	InteractiveAsyncCtx *ctx = g_task_get_task_data(task);
+	GError *error = NULL;
+	gchar *response = NULL;
+	gboolean ok;
+
+	ok = mib_dbus_identity_broker1_call_acquire_token_silently_finish(
+		proxy, &response, res, &error);
+	if (ok) {
+		JsonObject *token_json = json_object_from_string(response);
+		g_free(response);
+		if (token_json) {
+			debug_print_json_object("mib_acquire_token_silent", "response",
+									token_json);
+			MIBPrt *token = mib_prt_from_json(token_json, ctx->account);
+			json_object_unref(token_json);
+			if (token) {
+				g_task_return_pointer(task, token, g_object_unref);
+				g_object_unref(task);
+				return;
+			}
+		}
+	} else {
+		g_error_free(error);
+	}
+
+	/* Silent failed, fall back to interactive */
+	interactive_async_start_interactive(task);
+}
+
+static void interactive_get_accounts_cb(GObject *source_object,
+										GAsyncResult *res, gpointer user_data)
+{
+	GTask *task = G_TASK(user_data);
+	mibdbusIdentityBroker1 *proxy = MIB_DBUS_IDENTITY_BROKER1(source_object);
+	InteractiveAsyncCtx *ctx = g_task_get_task_data(task);
+	MIBClientApp *app = g_task_get_source_object(task);
+	GError *error = NULL;
+	gchar *response = NULL;
+	gboolean ok;
+
+	ok = mib_dbus_identity_broker1_call_get_accounts_finish(proxy, &response,
+															res, &error);
+	if (!ok) {
+		g_task_return_error(task, error);
+		g_object_unref(task);
+		return;
+	}
+
+	GSList *accounts = get_accounts_process_response(response);
+	g_free(response);
+
+	MIBAccount *account = find_account_by_upn(accounts, ctx->login_hint);
+
+	if (!account) {
+		g_slist_free_full(accounts, (GDestroyNotify)g_object_unref);
+		g_task_return_new_error(task, G_IO_ERROR, G_IO_ERROR_NOT_FOUND,
+								"could not find account for login hint");
+		g_object_unref(task);
+		return;
+	}
+
+	ctx->account = account;
+	g_slist_free_full(accounts, (GDestroyNotify)g_object_unref);
+
+	/* Try silent first (unless enforce_interactive) */
+	if (!mib_client_app_get_enforce_interactive(app)) {
+		gchar *data = acquire_token_silent_prepare_request(
+			app, ctx->account, ctx->scopes, ctx->claims_challenge,
+			ctx->pop_params, NULL);
+
+		mib_dbus_identity_broker1_call_acquire_token_silently(
+			mib_client_app_get_broker(app),
+			MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
+			mib_client_app_get_correlation_id(app), data,
+			mib_client_app_get_cancellable(app), interactive_silent_cb, task);
+		g_free(data);
+		return;
+	}
+
+	/* Go straight to interactive */
+	interactive_async_start_interactive(task);
+}
+
+void mib_client_app_acquire_token_interactive_async(
+	MIBClientApp *app, GSList *scopes, enum MIB_PROMPT prompt,
+	const gchar *login_hint, const gchar *domain_hint,
+	const gchar *claims_challenge, MIBPopParams *pop_params,
+	GAsyncReadyCallback callback, gpointer user_data)
+{
+	GTask *task;
+	InteractiveAsyncCtx *ctx;
+
+	g_assert(app);
+	g_assert(scopes);
+
+	task = g_task_new(app, mib_client_app_get_cancellable(app), callback,
+					  user_data);
+
+	ctx = g_new0(InteractiveAsyncCtx, 1);
+	ctx->scopes = g_slist_copy_deep(scopes, copy_string, NULL);
+	ctx->prompt = prompt;
+	ctx->login_hint = g_strdup(login_hint);
+	ctx->domain_hint = g_strdup(domain_hint);
+	ctx->claims_challenge = g_strdup(claims_challenge);
+	ctx->pop_params = pop_params ? g_object_ref(pop_params) : NULL;
+	g_task_set_task_data(task, ctx, interactive_async_ctx_free);
+
+	/* Step 1: get accounts async */
+	gchar *data = get_accounts_prepare_request(app);
+	mib_dbus_identity_broker1_call_get_accounts(
+		mib_client_app_get_broker(app), MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
+		mib_client_app_get_correlation_id(app), data,
+		mib_client_app_get_cancellable(app), interactive_get_accounts_cb, task);
+	g_free(data);
+}
+
+MIBPrt *mib_client_app_acquire_token_interactive_finish(MIBClientApp *app,
+														GAsyncResult *result,
+														GError **error)
+{
+	g_assert(app);
+	g_assert(g_task_is_valid(result, app));
+
+	return g_task_propagate_pointer(G_TASK(result), error);
 }
 
 static gchar *acquire_prt_sso_cookie_request_prepare(MIBClientApp *app,

--- a/src/mib-client-app.c
+++ b/src/mib-client-app.c
@@ -462,8 +462,7 @@ static gchar *acquire_token_silent_prepare_request(
 
 	JsonObject *params_obj = json_object_new();
 	json_object_set_member(params_obj, "authParameters", auth_params_node);
-	debug_print_json_object("mib_acquire_token_silent", "request",
-							params_obj);
+	debug_print_json_object("mib_acquire_token_silent", "request", params_obj);
 	gchar *data = json_object_to_string(params_obj);
 	json_object_unref(params_obj);
 
@@ -789,20 +788,40 @@ gchar *mib_client_app_generate_signed_http_request(MIBClientApp *app,
 	return access_token;
 }
 
-static int mib_remove_account_raw(MIBClientApp *app, JsonObject *account)
+static gchar *remove_account_prepare_request(MIBClientApp *app,
+											 MIBAccount *account)
+{
+	JsonObject *params = json_object_new();
+	json_object_set_string_member(params, "clientId", app->client_id);
+	json_object_set_object_member(params, "account",
+								  mib_account_to_json(account));
+
+	debug_print_json_object("mib_remove_account", "request", params);
+
+	gchar *data = json_object_to_string(params);
+	json_object_unref(params);
+	return data;
+}
+
+static void remove_account_process_response(const gchar *response)
+{
+	JsonObject *resp_json = json_object_from_string(response);
+	debug_print_json_object("mib_remove_account", "response", resp_json);
+	if (resp_json)
+		json_object_unref(resp_json);
+}
+
+int mib_client_app_remove_account(MIBClientApp *app, MIBAccount *account)
 {
 	GError *error = NULL;
 	gboolean ok;
 	gchar *response = NULL;
+	gchar *data = NULL;
 
-	JsonObject *params = json_object_new();
-	json_object_set_string_member(params, "clientId", app->client_id);
-	json_object_set_object_member(params, "account", json_object_ref(account));
+	g_assert(app);
+	g_assert(account);
 
-	debug_print_json_object("mib_remove_account_raw", "request", params);
-
-	gchar *data = json_object_to_string(params);
-	json_object_unref(params);
+	data = remove_account_prepare_request(app, account);
 	ok = mib_dbus_identity_broker1_call_remove_account_sync(
 		mib_client_app_get_broker(app), MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
 		mib_client_app_get_correlation_id(app), data, &response,
@@ -814,23 +833,7 @@ static int mib_remove_account_raw(MIBClientApp *app, JsonObject *account)
 		g_error_free(error);
 		return -1;
 	}
-	JsonObject *resp_json = json_object_from_string(response);
+	remove_account_process_response(response);
 	g_free(response);
-	debug_print_json_object("mib_remove_account_raw", "response", resp_json);
-	if (resp_json)
-		json_object_unref(resp_json);
 	return 0;
-}
-
-int mib_client_app_remove_account(MIBClientApp *app, MIBAccount *account)
-{
-	g_assert(app);
-	g_assert(account);
-	int ret = 0;
-
-	JsonObject *account_json = mib_account_to_json(account);
-	ret = mib_remove_account_raw(app, account_json);
-
-	json_object_unref(account_json);
-	return ret;
 }

--- a/src/mib-client-app.c
+++ b/src/mib-client-app.c
@@ -136,13 +136,10 @@ static gchar *mib_prompt_to_str(enum MIB_PROMPT prompt)
 	}
 }
 
-static JsonObject *mib_client_app_get_accounts_raw(MIBClientApp *app)
+static gchar *get_accounts_prepare_request(MIBClientApp *app)
 {
-	GError *error = NULL;
-	gchar *response = NULL;
 	JsonBuilder *builder;
 	JsonNode *root;
-	gboolean ok;
 
 	builder = json_builder_new();
 	json_builder_begin_object(builder);
@@ -154,89 +151,32 @@ static JsonObject *mib_client_app_get_accounts_raw(MIBClientApp *app)
 	root = json_builder_get_root(builder);
 	g_object_unref(builder);
 	JsonObject *params = json_node_get_object(root);
-	debug_print_json_object("mib_client_app_get_accounts_raw", "request",
-							params);
+	debug_print_json_object("mib_client_app_get_accounts", "request", params);
 	gchar *data = json_object_to_string(params);
 	json_node_unref(root);
+	return data;
+}
 
-	ok = mib_dbus_identity_broker1_call_get_accounts_sync(
-		mib_client_app_get_broker(app), MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
-		mib_client_app_get_correlation_id(app), data, &response,
-		mib_client_app_get_cancellable(app), &error);
-	g_free(data);
-	if (!ok) {
-		g_warning("could not get accounts: %s", error->message);
-		g_error_free(error);
-		return NULL;
-	}
+static GSList *get_accounts_process_response(const gchar *response)
+{
+	JsonArray *accounts_array = NULL;
+	GSList *accounts_list = NULL;
+	MIBAccount *mib_account = NULL;
+
 	JsonObject *accounts = json_object_from_string(response);
-	g_free(response);
 	if (!accounts) {
 		g_warning("could not parse accounts response");
 		return NULL;
 	}
-	debug_print_json_object("mib_client_app_get_accounts_raw", "response",
+	debug_print_json_object("mib_client_app_get_accounts", "response",
 							accounts);
-	return accounts;
-}
 
-/**
- * If no upn is provided, return the first account.
- * On error or when the no account has a matching upn return null.
- */
-static JsonObject *mib_client_app_get_account_by_upn_raw(MIBClientApp *app,
-														 const gchar *upn)
-{
-	JsonObject *accounts = mib_client_app_get_accounts_raw(app);
-	JsonObject *account = NULL;
-	if (!accounts) {
-		return NULL;
-	}
-	JsonArray *accounts_array =
-		json_object_get_array_member(accounts, "accounts");
-	if (!accounts_array) {
-		goto err;
-	}
-	for (guint i = 0; i < json_array_get_length(accounts_array); i++) {
-		JsonObject *_account = json_array_get_object_element(accounts_array, i);
-		if (!upn) {
-			g_debug("no upn provided");
-			account = _account;
-			break;
-		}
-		if (!json_object_has_member(_account, "username"))
-			continue;
-		const gchar *username =
-			json_object_get_string_member(_account, "username");
-		if (g_strcmp0(username, upn) == 0) {
-			g_debug("account matching UPN found");
-			account = _account;
-			break;
-		}
-	}
-	if (account)
-		json_object_ref(account);
-err:
-	json_object_unref(accounts);
-	return account;
-}
-
-GSList *mib_client_app_get_accounts(MIBClientApp *self)
-{
-	g_assert(self);
-
-	JsonObject *accounts = mib_client_app_get_accounts_raw(self);
-	if (!accounts) {
-		return NULL;
-	}
 	if (!json_object_has_member(accounts, "accounts")) {
 		json_object_unref(accounts);
 		return NULL;
 	}
-	JsonArray *accounts_array =
-		json_object_get_array_member(accounts, "accounts");
-	GSList *accounts_list = NULL;
-	MIBAccount *mib_account = NULL;
+
+	accounts_array = json_object_get_array_member(accounts, "accounts");
 	for (guint i = 0; i < json_array_get_length(accounts_array); i++) {
 		JsonObject *account = json_array_get_object_element(accounts_array, i);
 		mib_account = mib_account_from_json(account);
@@ -250,19 +190,59 @@ GSList *mib_client_app_get_accounts(MIBClientApp *self)
 	return g_slist_reverse(accounts_list);
 }
 
+GSList *mib_client_app_get_accounts(MIBClientApp *app)
+{
+	GError *error = NULL;
+	gchar *response = NULL;
+	gchar *data = NULL;
+	GSList *accounts = NULL;
+	gboolean ok;
+
+	g_assert(app);
+
+	data = get_accounts_prepare_request(app);
+
+	ok = mib_dbus_identity_broker1_call_get_accounts_sync(
+		mib_client_app_get_broker(app), MIB_REQUIRED_BROKER_PROTOCOL_VERSION,
+		mib_client_app_get_correlation_id(app), data, &response,
+		mib_client_app_get_cancellable(app), &error);
+	g_free(data);
+	if (!ok) {
+		g_warning("could not get accounts: %s", error->message);
+		g_error_free(error);
+		return NULL;
+	}
+
+	accounts = get_accounts_process_response(response);
+	g_free(response);
+	return accounts;
+}
+
 MIBAccount *mib_client_app_get_account_by_upn(MIBClientApp *app,
 											  const gchar *upn)
 {
+	GSList *accounts = mib_client_app_get_accounts(app);
+	MIBAccount *account = NULL;
+
 	g_assert(app);
 
-	MIBAccount *mib_account = NULL;
-	JsonObject *account = mib_client_app_get_account_by_upn_raw(app, upn);
-	if (!account) {
-		return NULL;
+	for (GSList *iter = accounts; iter; iter = g_slist_next(iter)) {
+		account = (MIBAccount *)iter->data;
+		if (!upn) {
+			g_debug("no upn provided");
+			break;
+		}
+		if (g_strcmp0(mib_account_get_username(account), upn) == 0) {
+			g_debug("account matching UPN found");
+			break;
+		}
+		account = NULL;
 	}
-	mib_account = mib_account_from_json(account);
-	json_object_unref(account);
-	return mib_account;
+	if (account) {
+		g_object_ref(account);
+	}
+	g_slist_free_full(accounts, (GDestroyNotify)g_object_unref);
+	return account;
 }
 
 mibdbusIdentityBroker1 *mib_client_app_get_broker(MIBClientApp *self)
@@ -601,12 +581,13 @@ MIBPrt *mib_client_app_acquire_token_interactive(
 
 	MIBPrt *token = NULL;
 	JsonObject *token_json = NULL;
-	JsonObject *account_json =
-		mib_client_app_get_account_by_upn_raw(app, login_hint);
-	if (!account_json) {
+	JsonObject *account_json = NULL;
+	MIBAccount *fallback_account =
+		mib_client_app_get_account_by_upn(app, login_hint);
+	if (!fallback_account) {
 		return NULL;
 	}
-	MIBAccount *fallback_account = mib_account_from_json(account_json);
+	account_json = mib_account_to_json(fallback_account);
 
 	JsonArray *scopes_array = mib_scopes_to_json(scopes);
 	JsonObject *pop_params = auth_scheme ? mib_pop_params_to_json(auth_scheme) :

--- a/src/mib-client-app.c
+++ b/src/mib-client-app.c
@@ -297,22 +297,54 @@ void mib_client_app_set_enforce_interactive(MIBClientApp *self, int enforce)
 	self->enforce_interactive = (char)enforce;
 }
 
-static JsonObject *
-mib_get_linux_broker_version_raw(MIBClientApp *app,
-								 const gchar *msal_cpp_version)
+static gchar *
+linux_broker_version_prepare_request(MIBClientApp *app,
+									 const gchar *msal_cpp_version)
 {
-	GError *error = NULL;
 	JsonObject *params;
 	gchar *params_data;
-	gchar *response;
-	gboolean ok;
 
 	params = json_object_new();
 	json_object_set_string_member(params, "msalCppVersion", msal_cpp_version);
-	debug_print_json_object("mib_get_linux_broker_version_raw", "request",
-							params);
+	debug_print_json_object("mib_get_linux_broker_version", "request", params);
 	params_data = json_object_to_string(params);
 	json_object_unref(params);
+	return params_data;
+}
+
+static gchar *linux_broker_version_process_response(const gchar *response)
+{
+	gchar *version = NULL;
+	JsonObject *version_json = json_object_from_string(response);
+	if (!version_json)
+		goto err;
+	debug_print_json_object("mib_get_linux_broker_version", "response",
+							version_json);
+
+	if (!json_object_has_member(version_json, "linuxBrokerVersion")) {
+		goto err;
+	}
+	version = g_strdup(
+		json_object_get_string_member(version_json, "linuxBrokerVersion"));
+err:
+	if (version_json)
+		json_object_unref(version_json);
+	return version;
+}
+
+gchar *mib_client_app_get_linux_broker_version(MIBClientApp *app,
+											   const gchar *msal_cpp_version)
+{
+	GError *error = NULL;
+	gchar *params_data;
+	gchar *response;
+	gchar *version = NULL;
+	gboolean ok;
+
+	g_assert(app);
+	g_assert(msal_cpp_version);
+
+	params_data = linux_broker_version_prepare_request(app, msal_cpp_version);
 	if (!params_data) {
 		return NULL;
 	}
@@ -327,34 +359,9 @@ mib_get_linux_broker_version_raw(MIBClientApp *app,
 		g_error_free(error);
 		return NULL;
 	}
-	JsonObject *version = json_object_from_string(response);
-	if (!version)
-		goto err;
-	debug_print_json_object("mib_get_linux_broker_version_raw", "response",
-							version);
-err:
+
+	version = linux_broker_version_process_response(response);
 	g_free(response);
-	return version;
-}
-
-gchar *mib_client_app_get_linux_broker_version(MIBClientApp *app,
-											   const gchar *msal_cpp_version)
-{
-	g_assert(app);
-	g_assert(msal_cpp_version);
-
-	JsonObject *version_json = NULL;
-	gchar *version = NULL;
-	version_json = mib_get_linux_broker_version_raw(app, msal_cpp_version);
-	if (!version_json ||
-		!json_object_has_member(version_json, "linuxBrokerVersion")) {
-		goto err;
-	}
-	version = g_strdup(
-		json_object_get_string_member(version_json, "linuxBrokerVersion"));
-err:
-	if (version_json)
-		json_object_unref(version_json);
 	return version;
 }
 

--- a/src/mib-client-app.c
+++ b/src/mib-client-app.c
@@ -222,25 +222,11 @@ MIBAccount *mib_client_app_get_account_by_upn(MIBClientApp *app,
 											  const gchar *upn)
 {
 	GSList *accounts = mib_client_app_get_accounts(app);
-	MIBAccount *account = NULL;
+	MIBAccount *account;
 
 	g_assert(app);
 
-	for (GSList *iter = accounts; iter; iter = g_slist_next(iter)) {
-		account = (MIBAccount *)iter->data;
-		if (!upn) {
-			g_debug("no upn provided");
-			break;
-		}
-		if (g_strcmp0(mib_account_get_username(account), upn) == 0) {
-			g_debug("account matching UPN found");
-			break;
-		}
-		account = NULL;
-	}
-	if (account) {
-		g_object_ref(account);
-	}
+	account = find_account_by_upn(accounts, upn);
 	g_slist_free_full(accounts, (GDestroyNotify)g_object_unref);
 	return account;
 }

--- a/src/mib-utils.c
+++ b/src/mib-utils.c
@@ -77,6 +77,11 @@ JsonArray *mib_scopes_to_json(GSList *scopes)
 	return scopes_array;
 }
 
+gpointer copy_string(gconstpointer src, MIB_ARG_UNUSED gpointer data)
+{
+	return g_strdup((const gchar *)src);
+}
+
 MIBAccount *find_account_by_upn(GSList *accounts, const gchar *upn)
 {
 	for (GSList *iter = accounts; iter; iter = g_slist_next(iter)) {

--- a/src/mib-utils.c
+++ b/src/mib-utils.c
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-only
  */
 
+#include "mib-account-impl.h"
 #include "mib-utils.h"
 
 gchar *json_object_to_string(JsonObject *object)
@@ -74,4 +75,20 @@ JsonArray *mib_scopes_to_json(GSList *scopes)
 		json_array_add_string_element(scopes_array, iter->data);
 	}
 	return scopes_array;
+}
+
+MIBAccount *find_account_by_upn(GSList *accounts, const gchar *upn)
+{
+	for (GSList *iter = accounts; iter; iter = g_slist_next(iter)) {
+		MIBAccount *account = (MIBAccount *)iter->data;
+		if (!upn) {
+			g_debug("no upn provided");
+			return g_object_ref(account);
+		}
+		if (g_strcmp0(mib_account_get_username(account), upn) == 0) {
+			g_debug("account matching UPN found");
+			return g_object_ref(account);
+		}
+	}
+	return NULL;
 }

--- a/src/mib-utils.h
+++ b/src/mib-utils.h
@@ -23,6 +23,11 @@ void debug_print_json_object(const gchar *func, const gchar *scope,
 JsonArray *mib_scopes_to_json(GSList *scopes);
 
 /**
+ * Helper to deep copy strings in a GSList.
+ */
+gpointer copy_string(gconstpointer src, MIB_ARG_UNUSED gpointer data);
+
+/**
  * Find an account matching @upn in a list.
  * Returns a new reference or NULL.
  */

--- a/src/mib-utils.h
+++ b/src/mib-utils.h
@@ -14,8 +14,16 @@
 #include <glib-2.0/glib.h>
 #include <json-glib/json-glib.h>
 
+typedef struct _MIBAccount MIBAccount;
+
 gchar *json_object_to_string(JsonObject *object);
 JsonObject *json_object_from_string(const gchar *data);
 void debug_print_json_object(const gchar *func, const gchar *scope,
 							 JsonObject *object);
 JsonArray *mib_scopes_to_json(GSList *scopes);
+
+/**
+ * Find an account matching @upn in a list.
+ * Returns a new reference or NULL.
+ */
+MIBAccount *find_account_by_upn(GSList *accounts, const gchar *upn);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: (C) 2026 Siemens
+# SPDX-License-Identifier: LGPL-2.1-only
+
+test_deps = [glibdep, giodep, jsondep, uuiddep]
+
+# Build a static test-only version of the library that includes both
+# the library sources and the identity-broker generated code in one unit,
+# avoiding duplicate GType registrations.
+test_lib_src = []
+foreach src : libsso_mib_src
+  test_lib_src += files('../' + src)
+endforeach
+
+libsso_mib_test = static_library('sso-mib-test',
+  test_lib_src, identity_broker,
+  c_args : ['-DBUILDING_SSO_MIB=1',
+            '-DSSO_MIB_COMPILATION=1',
+            '-DG_LOG_DOMAIN="ssomib"',
+            '-Wno-pedantic'],
+  include_directories : public_headers,
+  dependencies : [giodep, glibdep, jsondep, uuiddep],
+)
+
+test_client_app = executable('test-client-app',
+  'test-client-app.c', 'mock-broker.c', identity_broker[1],
+  c_args : ['-Wno-pedantic'],
+  include_directories : public_headers,
+  link_with : [libsso_mib_test],
+  dependencies : test_deps,
+)
+
+test('client-app', test_client_app)

--- a/tests/mock-broker.c
+++ b/tests/mock-broker.c
@@ -1,0 +1,300 @@
+/*
+ * SPDX-FileCopyrightText: (C) 2025 Siemens
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "mock-broker.h"
+#include "identity-broker.h"
+
+struct _MockBroker {
+	GTestDBus *dbus;
+	GDBusConnection *conn;
+	mibdbusIdentityBroker1 *skeleton;
+	guint name_id;
+
+	/* Dedicated thread and context for processing skeleton method calls */
+	GMainContext *context;
+	GMainLoop *loop;
+	GThread *thread;
+
+	gchar *get_accounts_response;
+	gchar *acquire_token_silently_response;
+	gchar *acquire_token_interactively_response;
+	gchar *acquire_prt_sso_cookie_response;
+	gchar *generate_signed_http_request_response;
+	gchar *remove_account_response;
+	gchar *get_linux_broker_version_response;
+
+	GHashTable *last_requests; /* method_name -> last request JSON */
+};
+
+static void store_request(MockBroker *self, const gchar *method,
+						  const gchar *request)
+{
+	g_hash_table_replace(self->last_requests, g_strdup(method),
+						 g_strdup(request));
+}
+
+static gboolean on_handle_get_accounts(mibdbusIdentityBroker1 *skeleton,
+									   GDBusMethodInvocation *invocation,
+									   const gchar *protocol_version,
+									   const gchar *correlation_id,
+									   const gchar *request, gpointer user_data)
+{
+	MockBroker *self = user_data;
+	store_request(self, "getAccounts", request);
+	mib_dbus_identity_broker1_complete_get_accounts(
+		skeleton, invocation,
+		self->get_accounts_response ? self->get_accounts_response : "{}");
+	return TRUE;
+}
+
+static gboolean on_handle_acquire_token_silently(
+	mibdbusIdentityBroker1 *skeleton, GDBusMethodInvocation *invocation,
+	const gchar *protocol_version, const gchar *correlation_id,
+	const gchar *request, gpointer user_data)
+{
+	MockBroker *self = user_data;
+	store_request(self, "acquireTokenSilently", request);
+	mib_dbus_identity_broker1_complete_acquire_token_silently(
+		skeleton, invocation,
+		self->acquire_token_silently_response ?
+			self->acquire_token_silently_response :
+			"{}");
+	return TRUE;
+}
+
+static gboolean on_handle_acquire_token_interactively(
+	mibdbusIdentityBroker1 *skeleton, GDBusMethodInvocation *invocation,
+	const gchar *protocol_version, const gchar *correlation_id,
+	const gchar *request, gpointer user_data)
+{
+	MockBroker *self = user_data;
+	store_request(self, "acquireTokenInteractively", request);
+	mib_dbus_identity_broker1_complete_acquire_token_interactively(
+		skeleton, invocation,
+		self->acquire_token_interactively_response ?
+			self->acquire_token_interactively_response :
+			"{}");
+	return TRUE;
+}
+
+static gboolean on_handle_acquire_prt_sso_cookie(
+	mibdbusIdentityBroker1 *skeleton, GDBusMethodInvocation *invocation,
+	const gchar *protocol_version, const gchar *correlation_id,
+	const gchar *request, gpointer user_data)
+{
+	MockBroker *self = user_data;
+	store_request(self, "acquirePrtSsoCookie", request);
+	mib_dbus_identity_broker1_complete_acquire_prt_sso_cookie(
+		skeleton, invocation,
+		self->acquire_prt_sso_cookie_response ?
+			self->acquire_prt_sso_cookie_response :
+			"{}");
+	return TRUE;
+}
+
+static gboolean on_handle_generate_signed_http_request(
+	mibdbusIdentityBroker1 *skeleton, GDBusMethodInvocation *invocation,
+	const gchar *protocol_version, const gchar *correlation_id,
+	const gchar *request, gpointer user_data)
+{
+	MockBroker *self = user_data;
+	store_request(self, "generateSignedHttpRequest", request);
+	mib_dbus_identity_broker1_complete_generate_signed_http_request(
+		skeleton, invocation,
+		self->generate_signed_http_request_response ?
+			self->generate_signed_http_request_response :
+			"{}");
+	return TRUE;
+}
+
+static gboolean on_handle_remove_account(mibdbusIdentityBroker1 *skeleton,
+										 GDBusMethodInvocation *invocation,
+										 const gchar *protocol_version,
+										 const gchar *correlation_id,
+										 const gchar *request,
+										 gpointer user_data)
+{
+	MockBroker *self = user_data;
+	store_request(self, "removeAccount", request);
+	mib_dbus_identity_broker1_complete_remove_account(
+		skeleton, invocation,
+		self->remove_account_response ? self->remove_account_response : "{}");
+	return TRUE;
+}
+
+static gboolean on_handle_get_linux_broker_version(
+	mibdbusIdentityBroker1 *skeleton, GDBusMethodInvocation *invocation,
+	const gchar *protocol_version, const gchar *correlation_id,
+	const gchar *request, gpointer user_data)
+{
+	MockBroker *self = user_data;
+	store_request(self, "getLinuxBrokerVersion", request);
+	mib_dbus_identity_broker1_complete_get_linux_broker_version(
+		skeleton, invocation,
+		self->get_linux_broker_version_response ?
+			self->get_linux_broker_version_response :
+			"{}");
+	return TRUE;
+}
+
+static gpointer mock_broker_thread_func(gpointer data)
+{
+	MockBroker *self = data;
+	g_main_loop_run(self->loop);
+	return NULL;
+}
+
+MockBroker *mock_broker_new(void)
+{
+	MockBroker *self = g_new0(MockBroker, 1);
+	GError *error = NULL;
+
+	self->last_requests =
+		g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+
+	/* Create a dedicated context for the broker thread */
+	self->context = g_main_context_new();
+	self->loop = g_main_loop_new(self->context, FALSE);
+
+	/* Start an isolated session bus */
+	self->dbus = g_test_dbus_new(G_TEST_DBUS_NONE);
+	g_test_dbus_up(self->dbus);
+
+	/* Get a private connection for the skeleton.
+	 * Push our context so the connection dispatches on it. */
+	g_main_context_push_thread_default(self->context);
+
+	self->conn = g_dbus_connection_new_for_address_sync(
+		g_test_dbus_get_bus_address(self->dbus),
+		G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT |
+			G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION,
+		NULL, NULL, &error);
+	g_assert_no_error(error);
+
+	/* Create and export skeleton */
+	self->skeleton = mib_dbus_identity_broker1_skeleton_new();
+
+	g_signal_connect(self->skeleton, "handle-get-accounts",
+					 G_CALLBACK(on_handle_get_accounts), self);
+	g_signal_connect(self->skeleton, "handle-acquire-token-silently",
+					 G_CALLBACK(on_handle_acquire_token_silently), self);
+	g_signal_connect(self->skeleton, "handle-acquire-token-interactively",
+					 G_CALLBACK(on_handle_acquire_token_interactively), self);
+	g_signal_connect(self->skeleton, "handle-acquire-prt-sso-cookie",
+					 G_CALLBACK(on_handle_acquire_prt_sso_cookie), self);
+	g_signal_connect(self->skeleton, "handle-generate-signed-http-request",
+					 G_CALLBACK(on_handle_generate_signed_http_request), self);
+	g_signal_connect(self->skeleton, "handle-remove-account",
+					 G_CALLBACK(on_handle_remove_account), self);
+	g_signal_connect(self->skeleton, "handle-get-linux-broker-version",
+					 G_CALLBACK(on_handle_get_linux_broker_version), self);
+
+	gboolean exported = g_dbus_interface_skeleton_export(
+		G_DBUS_INTERFACE_SKELETON(self->skeleton), self->conn,
+		"/com/microsoft/identity/broker1", &error);
+	g_assert_no_error(error);
+	g_assert_true(exported);
+
+	/* Own the well-known name */
+	self->name_id = g_bus_own_name_on_connection(
+		self->conn, "com.microsoft.identity.broker1",
+		G_BUS_NAME_OWNER_FLAGS_NONE, NULL, NULL, NULL, NULL);
+
+	g_main_context_pop_thread_default(self->context);
+
+	/* Start the broker thread to handle incoming method calls */
+	self->thread = g_thread_new("mock-broker", mock_broker_thread_func, self);
+
+	/* Give the thread a moment to start and own the name */
+	g_usleep(100 * 1000);
+
+	return self;
+}
+
+void mock_broker_free(MockBroker *self)
+{
+	if (!self)
+		return;
+
+	/* Stop the broker thread */
+	g_main_loop_quit(self->loop);
+	g_thread_join(self->thread);
+
+	g_bus_unown_name(self->name_id);
+	g_dbus_interface_skeleton_unexport(
+		G_DBUS_INTERFACE_SKELETON(self->skeleton));
+	g_clear_object(&self->skeleton);
+	g_clear_object(&self->conn);
+	g_test_dbus_down(self->dbus);
+	g_clear_object(&self->dbus);
+
+	g_main_loop_unref(self->loop);
+	g_main_context_unref(self->context);
+
+	g_free(self->get_accounts_response);
+	g_free(self->acquire_token_silently_response);
+	g_free(self->acquire_token_interactively_response);
+	g_free(self->acquire_prt_sso_cookie_response);
+	g_free(self->generate_signed_http_request_response);
+	g_free(self->remove_account_response);
+	g_free(self->get_linux_broker_version_response);
+
+	g_hash_table_unref(self->last_requests);
+	g_free(self);
+}
+
+void mock_broker_set_get_accounts_response(MockBroker *self, const gchar *json)
+{
+	g_free(self->get_accounts_response);
+	self->get_accounts_response = g_strdup(json);
+}
+
+void mock_broker_set_acquire_token_silently_response(MockBroker *self,
+													 const gchar *json)
+{
+	g_free(self->acquire_token_silently_response);
+	self->acquire_token_silently_response = g_strdup(json);
+}
+
+void mock_broker_set_acquire_token_interactively_response(MockBroker *self,
+														  const gchar *json)
+{
+	g_free(self->acquire_token_interactively_response);
+	self->acquire_token_interactively_response = g_strdup(json);
+}
+
+void mock_broker_set_acquire_prt_sso_cookie_response(MockBroker *self,
+													 const gchar *json)
+{
+	g_free(self->acquire_prt_sso_cookie_response);
+	self->acquire_prt_sso_cookie_response = g_strdup(json);
+}
+
+void mock_broker_set_generate_signed_http_request_response(MockBroker *self,
+														   const gchar *json)
+{
+	g_free(self->generate_signed_http_request_response);
+	self->generate_signed_http_request_response = g_strdup(json);
+}
+
+void mock_broker_set_remove_account_response(MockBroker *self,
+											 const gchar *json)
+{
+	g_free(self->remove_account_response);
+	self->remove_account_response = g_strdup(json);
+}
+
+void mock_broker_set_get_linux_broker_version_response(MockBroker *self,
+													   const gchar *json)
+{
+	g_free(self->get_linux_broker_version_response);
+	self->get_linux_broker_version_response = g_strdup(json);
+}
+
+const gchar *mock_broker_get_last_request(MockBroker *self,
+										  const gchar *method_name)
+{
+	return g_hash_table_lookup(self->last_requests, method_name);
+}

--- a/tests/mock-broker.h
+++ b/tests/mock-broker.h
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: (C) 2025 Siemens
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+typedef struct _MockBroker MockBroker;
+
+MockBroker *mock_broker_new(void);
+void mock_broker_free(MockBroker *self);
+
+/* Configure canned responses (the mock returns these verbatim) */
+void mock_broker_set_get_accounts_response(MockBroker *self, const gchar *json);
+void mock_broker_set_acquire_token_silently_response(MockBroker *self,
+													 const gchar *json);
+void mock_broker_set_acquire_token_interactively_response(MockBroker *self,
+														  const gchar *json);
+void mock_broker_set_acquire_prt_sso_cookie_response(MockBroker *self,
+													 const gchar *json);
+void mock_broker_set_generate_signed_http_request_response(MockBroker *self,
+														   const gchar *json);
+void mock_broker_set_remove_account_response(MockBroker *self,
+											 const gchar *json);
+void mock_broker_set_get_linux_broker_version_response(MockBroker *self,
+													   const gchar *json);
+
+/* Retrieve the last request JSON received by each method */
+const gchar *mock_broker_get_last_request(MockBroker *self,
+										  const gchar *method_name);

--- a/tests/test-client-app.c
+++ b/tests/test-client-app.c
@@ -330,6 +330,97 @@ static void test_acquire_token_silent_async(void)
 	g_object_unref(app);
 }
 
+/* --- Test: acquire token interactive async --- */
+
+static void acquire_token_interactive_async_cb(GObject *source_object,
+											   GAsyncResult *res,
+											   gpointer user_data)
+{
+	GMainLoop *loop = user_data;
+	MIBClientApp *app = MIB_CLIENT_APP(source_object);
+	GError *error = NULL;
+
+	MIBPrt *token =
+		mib_client_app_acquire_token_interactive_finish(app, res, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(token);
+
+	g_assert_cmpstr(mib_prt_get_access_token(token), ==,
+					"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.test");
+
+	g_object_unref(token);
+	g_main_loop_quit(loop);
+}
+
+static void test_acquire_token_interactive_async(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+	mock_broker_set_acquire_token_silently_response(broker, TOKEN_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	GSList *scopes = g_slist_append(NULL, (gpointer)MIB_SCOPE_GRAPH_DEFAULT);
+
+	GMainLoop *loop = g_main_loop_new(NULL, FALSE);
+	mib_client_app_acquire_token_interactive_async(
+		app, scopes, MIB_PROMPT_UNSET, "testuser@example.com", NULL, NULL, NULL,
+		acquire_token_interactive_async_cb, loop);
+	g_main_loop_run(loop);
+
+	g_main_loop_unref(loop);
+	g_slist_free(scopes);
+	g_object_unref(app);
+}
+
+static void acquire_token_interactive_enforce_async_cb(GObject *source_object,
+													   GAsyncResult *res,
+													   gpointer user_data)
+{
+	GMainLoop *loop = user_data;
+	MIBClientApp *app = MIB_CLIENT_APP(source_object);
+	GError *error = NULL;
+
+	MIBPrt *token =
+		mib_client_app_acquire_token_interactive_finish(app, res, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(token);
+
+	g_assert_cmpstr(mib_prt_get_access_token(token), ==,
+					"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.test");
+
+	g_object_unref(token);
+	g_main_loop_quit(loop);
+}
+
+static void test_acquire_token_interactive_async_enforce(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+	mock_broker_set_acquire_token_interactively_response(broker,
+														 TOKEN_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	mib_client_app_set_enforce_interactive(app, 1);
+
+	GSList *scopes = g_slist_append(NULL, (gpointer)MIB_SCOPE_GRAPH_DEFAULT);
+
+	GMainLoop *loop = g_main_loop_new(NULL, FALSE);
+	mib_client_app_acquire_token_interactive_async(
+		app, scopes, MIB_PROMPT_UNSET, "testuser@example.com", NULL, NULL, NULL,
+		acquire_token_interactive_enforce_async_cb, loop);
+	g_main_loop_run(loop);
+
+	g_main_loop_unref(loop);
+	g_slist_free(scopes);
+	g_object_unref(app);
+}
+
 /* --- Test: acquire PRT SSO cookie --- */
 
 static void test_acquire_prt_sso_cookie(void)
@@ -677,6 +768,10 @@ int main(int argc, char *argv[])
 					test_acquire_token_silent_bad_response);
 	g_test_add_func("/client-app/acquire-token-silent-async",
 					test_acquire_token_silent_async);
+	g_test_add_func("/client-app/acquire-token-interactive-async",
+					test_acquire_token_interactive_async);
+	g_test_add_func("/client-app/acquire-token-interactive-async-enforce",
+					test_acquire_token_interactive_async_enforce);
 	g_test_add_func("/client-app/acquire-prt-sso-cookie",
 					test_acquire_prt_sso_cookie);
 	g_test_add_func("/client-app/acquire-prt-sso-cookie-async",

--- a/tests/test-client-app.c
+++ b/tests/test-client-app.c
@@ -124,6 +124,45 @@ static void test_get_accounts_empty(void)
 	g_object_unref(app);
 }
 
+/* --- Test: get accounts async --- */
+
+static void get_accounts_async_cb(GObject *source_object, GAsyncResult *res,
+								  gpointer user_data)
+{
+	GMainLoop *loop = user_data;
+	MIBClientApp *app = MIB_CLIENT_APP(source_object);
+	GError *error = NULL;
+
+	GSList *accounts = mib_client_app_get_accounts_finish(app, res, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(accounts);
+	g_assert_cmpuint(g_slist_length(accounts), ==, 1);
+
+	MIBAccount *account = accounts->data;
+	g_assert_cmpstr(mib_account_get_username(account), ==,
+					"testuser@example.com");
+
+	g_slist_free_full(accounts, (GDestroyNotify)g_object_unref);
+	g_main_loop_quit(loop);
+}
+
+static void test_get_accounts_async(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	GMainLoop *loop = g_main_loop_new(NULL, FALSE);
+	mib_client_app_get_accounts_async(app, get_accounts_async_cb, loop);
+	g_main_loop_run(loop);
+
+	g_main_loop_unref(loop);
+	g_object_unref(app);
+}
+
 /* --- Test: get account by UPN --- */
 
 static void test_get_account_by_upn(void)
@@ -244,6 +283,53 @@ static void test_acquire_token_silent_bad_response(void)
 	g_object_unref(app);
 }
 
+/* --- Test: acquire token silent async --- */
+
+static void acquire_token_silent_async_cb(GObject *source_object,
+										  GAsyncResult *res, gpointer user_data)
+{
+	GMainLoop *loop = user_data;
+	MIBClientApp *app = MIB_CLIENT_APP(source_object);
+	GError *error = NULL;
+
+	MIBPrt *token =
+		mib_client_app_acquire_token_silent_finish(app, res, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(token);
+
+	g_object_unref(token);
+	g_main_loop_quit(loop);
+}
+
+static void test_acquire_token_silent_async(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+	mock_broker_set_acquire_token_silently_response(broker, TOKEN_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	MIBAccount *account =
+		mib_client_app_get_account_by_upn(app, "testuser@example.com");
+	g_assert_nonnull(account);
+
+	GSList *scopes = g_slist_append(NULL, (gpointer)MIB_SCOPE_GRAPH_DEFAULT);
+
+	GMainLoop *loop = g_main_loop_new(NULL, FALSE);
+	mib_client_app_acquire_token_silent_async(app, account, scopes, NULL, NULL,
+											  NULL,
+											  acquire_token_silent_async_cb,
+											  loop);
+	g_main_loop_run(loop);
+
+	g_main_loop_unref(loop);
+	g_slist_free(scopes);
+	g_object_unref(account);
+	g_object_unref(app);
+}
+
 /* --- Test: acquire PRT SSO cookie --- */
 
 static void test_acquire_prt_sso_cookie(void)
@@ -277,6 +363,60 @@ static void test_acquire_prt_sso_cookie(void)
 	g_object_unref(app);
 }
 
+/* --- Test: acquire PRT SSO cookie async --- */
+
+static void acquire_prt_sso_cookie_async_cb(GObject *source_object,
+											GAsyncResult *res,
+											gpointer user_data)
+{
+	GMainLoop *loop = user_data;
+	MIBClientApp *app = MIB_CLIENT_APP(source_object);
+	GError *error = NULL;
+
+	MIBPrtSsoCookie *cookie =
+		mib_client_app_acquire_prt_sso_cookie_finish(app, res, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(cookie);
+
+	g_assert_cmpstr(mib_prt_sso_cookie_get_name(cookie), ==,
+					"x-ms-RefreshTokenCredential");
+	g_assert_cmpstr(mib_prt_sso_cookie_get_content(cookie), ==,
+					"cookie-content-value");
+
+	g_object_unref(cookie);
+	g_main_loop_quit(loop);
+}
+
+static void test_acquire_prt_sso_cookie_async(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+	mock_broker_set_acquire_prt_sso_cookie_response(broker,
+													PRT_SSO_COOKIE_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	MIBAccount *account =
+		mib_client_app_get_account_by_upn(app, "testuser@example.com");
+	g_assert_nonnull(account);
+
+	GSList *scopes = g_slist_append(NULL, (gpointer)MIB_SCOPE_GRAPH_DEFAULT);
+
+	GMainLoop *loop = g_main_loop_new(NULL, FALSE);
+	mib_client_app_acquire_prt_sso_cookie_async(app, account,
+												MIB_SSO_URL_DEFAULT, scopes,
+												acquire_prt_sso_cookie_async_cb,
+												loop);
+	g_main_loop_run(loop);
+
+	g_main_loop_unref(loop);
+	g_slist_free(scopes);
+	g_object_unref(account);
+	g_object_unref(app);
+}
+
 /* --- Test: generate signed HTTP request --- */
 
 static void test_generate_signed_http_request(void)
@@ -304,6 +444,51 @@ static void test_generate_signed_http_request(void)
 	g_object_unref(app);
 }
 
+/* --- Test: generate signed HTTP request async --- */
+
+static void generate_signed_http_request_async_cb(GObject *source_object,
+												  GAsyncResult *res,
+												  gpointer user_data)
+{
+	GMainLoop *loop = user_data;
+	MIBClientApp *app = MIB_CLIENT_APP(source_object);
+	GError *error = NULL;
+
+	gchar *signed_req =
+		mib_client_app_generate_signed_http_request_finish(app, res, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(signed_req);
+	g_assert_cmpstr(signed_req, ==, "signed-request-token-value");
+
+	g_free(signed_req);
+	g_main_loop_quit(loop);
+}
+
+static void test_generate_signed_http_request_async(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+	mock_broker_set_generate_signed_http_request_response(
+		broker, SIGNED_HTTP_REQUEST_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	MIBAccount *account =
+		mib_client_app_get_account_by_upn(app, "testuser@example.com");
+	g_assert_nonnull(account);
+
+	GMainLoop *loop = g_main_loop_new(NULL, FALSE);
+	mib_client_app_generate_signed_http_request_async(
+		app, account, NULL, generate_signed_http_request_async_cb, loop);
+	g_main_loop_run(loop);
+
+	g_main_loop_unref(loop);
+	g_object_unref(account);
+	g_object_unref(app);
+}
+
 /* --- Test: remove account --- */
 
 static void test_remove_account(void)
@@ -327,6 +512,46 @@ static void test_remove_account(void)
 	g_object_unref(app);
 }
 
+/* --- Test: remove account async --- */
+
+static void remove_account_async_cb(GObject *source_object, GAsyncResult *res,
+									gpointer user_data)
+{
+	GMainLoop *loop = user_data;
+	MIBClientApp *app = MIB_CLIENT_APP(source_object);
+	GError *error = NULL;
+
+	int ret = mib_client_app_remove_account_finish(app, res, &error);
+	g_assert_no_error(error);
+	g_assert_cmpint(ret, ==, 0);
+
+	g_main_loop_quit(loop);
+}
+
+static void test_remove_account_async(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+	mock_broker_set_remove_account_response(broker, "{}");
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	MIBAccount *account =
+		mib_client_app_get_account_by_upn(app, "testuser@example.com");
+	g_assert_nonnull(account);
+
+	GMainLoop *loop = g_main_loop_new(NULL, FALSE);
+	mib_client_app_remove_account_async(app, account, remove_account_async_cb,
+										loop);
+	g_main_loop_run(loop);
+
+	g_main_loop_unref(loop);
+	g_object_unref(account);
+	g_object_unref(app);
+}
+
 /* --- Test: get Linux broker version --- */
 
 static void test_get_linux_broker_version(void)
@@ -344,6 +569,45 @@ static void test_get_linux_broker_version(void)
 	g_assert_cmpstr(version, ==, "2.1.0");
 
 	g_free(version);
+	g_object_unref(app);
+}
+
+/* --- Test: get Linux broker version async --- */
+
+static void get_linux_broker_version_async_cb(GObject *source_object,
+											  GAsyncResult *res,
+											  gpointer user_data)
+{
+	GMainLoop *loop = user_data;
+	MIBClientApp *app = MIB_CLIENT_APP(source_object);
+	GError *error = NULL;
+
+	gchar *version =
+		mib_client_app_get_linux_broker_version_finish(app, res, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(version);
+	g_assert_cmpstr(version, ==, "2.1.0");
+
+	g_free(version);
+	g_main_loop_quit(loop);
+}
+
+static void test_get_linux_broker_version_async(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_linux_broker_version_response(broker,
+													  BROKER_VERSION_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	GMainLoop *loop = g_main_loop_new(NULL, FALSE);
+	mib_client_app_get_linux_broker_version_async(
+		app, "1.28.0", get_linux_broker_version_async_cb, loop);
+	g_main_loop_run(loop);
+
+	g_main_loop_unref(loop);
 	g_object_unref(app);
 }
 
@@ -401,6 +665,7 @@ int main(int argc, char *argv[])
 					test_client_app_new_invalid_id);
 	g_test_add_func("/client-app/get-accounts", test_get_accounts);
 	g_test_add_func("/client-app/get-accounts-empty", test_get_accounts_empty);
+	g_test_add_func("/client-app/get-accounts-async", test_get_accounts_async);
 	g_test_add_func("/client-app/get-account-by-upn", test_get_account_by_upn);
 	g_test_add_func("/client-app/get-account-by-upn-not-found",
 					test_get_account_by_upn_not_found);
@@ -410,13 +675,23 @@ int main(int argc, char *argv[])
 					test_acquire_token_silent);
 	g_test_add_func("/client-app/acquire-token-silent-bad-response",
 					test_acquire_token_silent_bad_response);
+	g_test_add_func("/client-app/acquire-token-silent-async",
+					test_acquire_token_silent_async);
 	g_test_add_func("/client-app/acquire-prt-sso-cookie",
 					test_acquire_prt_sso_cookie);
+	g_test_add_func("/client-app/acquire-prt-sso-cookie-async",
+					test_acquire_prt_sso_cookie_async);
 	g_test_add_func("/client-app/generate-signed-http-request",
 					test_generate_signed_http_request);
+	g_test_add_func("/client-app/generate-signed-http-request-async",
+					test_generate_signed_http_request_async);
 	g_test_add_func("/client-app/remove-account", test_remove_account);
+	g_test_add_func("/client-app/remove-account-async",
+					test_remove_account_async);
 	g_test_add_func("/client-app/get-linux-broker-version",
 					test_get_linux_broker_version);
+	g_test_add_func("/client-app/get-linux-broker-version-async",
+					test_get_linux_broker_version_async);
 	g_test_add_func("/client-app/enforce-interactive",
 					test_enforce_interactive);
 	g_test_add_func("/client-app/redirect-uri", test_redirect_uri);

--- a/tests/test-client-app.c
+++ b/tests/test-client-app.c
@@ -1,0 +1,428 @@
+/*
+ * SPDX-FileCopyrightText: (C) 2025 Siemens
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <sso-mib.h>
+#include "mock-broker.h"
+
+#define TEST_CLIENT_ID "00000000-1111-2222-3333-444444444444"
+#define TEST_TENANT_ID "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+static MockBroker *broker = NULL;
+
+/* JSON response snippets */
+
+#define ACCOUNT_JSON                                 \
+	"{"                                              \
+	"\"environment\":\"login.microsoftonline.com\"," \
+	"\"givenName\":\"Test\","                        \
+	"\"homeAccountId\":\"home-account-id-1\","       \
+	"\"localAccountId\":\"local-account-id-1\","     \
+	"\"name\":\"Test User\","                        \
+	"\"passwordExpiry\":0,"                          \
+	"\"realm\":\"" TEST_TENANT_ID "\","              \
+	"\"username\":\"testuser@example.com\""          \
+	"}"
+
+#define GET_ACCOUNTS_RESPONSE "{\"accounts\":[" ACCOUNT_JSON "]}"
+
+#define GET_ACCOUNTS_EMPTY_RESPONSE "{\"accounts\":[]}"
+
+#define TOKEN_RESPONSE                                               \
+	"{\"brokerTokenResponse\":{"                                     \
+	"\"accessToken\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.test\"," \
+	"\"accessTokenType\":0,"                                         \
+	"\"account\":" ACCOUNT_JSON ","                                  \
+	"\"clientInfo\":\"client-info-value\","                          \
+	"\"expiresOn\":1700000000000,"                                   \
+	"\"grantedScopes\":\"https://graph.microsoft.com/.default\","    \
+	"\"idToken\":\"id-token-value\""                                 \
+	"}}"
+
+#define PRT_SSO_COOKIE_RESPONSE                        \
+	"{\"cookieName\":\"x-ms-RefreshTokenCredential\"," \
+	"\"cookieContent\":\"cookie-content-value\"}"
+
+#define SIGNED_HTTP_REQUEST_RESPONSE \
+	"{\"signedHttpRequest\":\"signed-request-token-value\"}"
+
+#define BROKER_VERSION_RESPONSE "{\"linuxBrokerVersion\":\"2.1.0\"}"
+
+/* --- Test: create client app --- */
+
+static void test_client_app_new(void)
+{
+	GError *error = NULL;
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+
+	g_assert_no_error(error);
+	g_assert_nonnull(app);
+	g_assert_cmpstr(mib_client_app_get_client_id(app), ==, TEST_CLIENT_ID);
+	g_assert_cmpstr(mib_client_app_get_authority(app), ==,
+					MIB_AUTHORITY_COMMON);
+	g_assert_nonnull(mib_client_app_get_correlation_id(app));
+
+	g_object_unref(app);
+}
+
+static void test_client_app_new_invalid_id(void)
+{
+	g_test_expect_message("ssomib", G_LOG_LEVEL_WARNING,
+						  "*client id is not a UUID*");
+	MIBClientApp *app = mib_public_client_app_new(
+		"not-a-uuid", MIB_AUTHORITY_COMMON, NULL, NULL);
+	g_assert_null(app);
+	g_test_assert_expected_messages();
+}
+
+/* --- Test: get accounts --- */
+
+static void test_get_accounts(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+	g_assert_nonnull(app);
+
+	GSList *accounts = mib_client_app_get_accounts(app);
+	g_assert_nonnull(accounts);
+	g_assert_cmpuint(g_slist_length(accounts), ==, 1);
+
+	MIBAccount *account = accounts->data;
+	g_assert_cmpstr(mib_account_get_username(account), ==,
+					"testuser@example.com");
+	g_assert_cmpstr(mib_account_get_environment(account), ==,
+					"login.microsoftonline.com");
+	g_assert_cmpstr(mib_account_get_home_account_id(account), ==,
+					"home-account-id-1");
+	g_assert_cmpstr(mib_account_get_local_account_id(account), ==,
+					"local-account-id-1");
+	g_assert_cmpstr(mib_account_get_name(account), ==, "Test User");
+	g_assert_cmpstr(mib_account_get_given_name(account), ==, "Test");
+
+	g_slist_free_full(accounts, (GDestroyNotify)g_object_unref);
+	g_object_unref(app);
+}
+
+static void test_get_accounts_empty(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_EMPTY_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	GSList *accounts = mib_client_app_get_accounts(app);
+	g_assert_null(accounts);
+
+	g_object_unref(app);
+}
+
+/* --- Test: get account by UPN --- */
+
+static void test_get_account_by_upn(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	MIBAccount *account =
+		mib_client_app_get_account_by_upn(app, "testuser@example.com");
+	g_assert_nonnull(account);
+	g_assert_cmpstr(mib_account_get_username(account), ==,
+					"testuser@example.com");
+
+	g_object_unref(account);
+	g_object_unref(app);
+}
+
+static void test_get_account_by_upn_not_found(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	MIBAccount *account =
+		mib_client_app_get_account_by_upn(app, "nobody@example.com");
+	g_assert_null(account);
+
+	g_object_unref(app);
+}
+
+static void test_get_account_by_upn_null(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	/* NULL upn returns first account */
+	MIBAccount *account = mib_client_app_get_account_by_upn(app, NULL);
+	g_assert_nonnull(account);
+	g_assert_cmpstr(mib_account_get_username(account), ==,
+					"testuser@example.com");
+
+	g_object_unref(account);
+	g_object_unref(app);
+}
+
+/* --- Test: acquire token silent --- */
+
+static void test_acquire_token_silent(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+	mock_broker_set_acquire_token_silently_response(broker, TOKEN_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	MIBAccount *account =
+		mib_client_app_get_account_by_upn(app, "testuser@example.com");
+	g_assert_nonnull(account);
+
+	GSList *scopes = g_slist_append(NULL, (gpointer)MIB_SCOPE_GRAPH_DEFAULT);
+	MIBPrt *token = mib_client_app_acquire_token_silent(app, account, scopes,
+														NULL, NULL, NULL);
+	g_assert_nonnull(token);
+
+	g_assert_cmpstr(mib_prt_get_access_token(token), ==,
+					"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.test");
+	g_assert_cmpint(mib_prt_get_access_token_type(token), ==,
+					MIB_AUTH_SCHEME_BEARER);
+	g_assert_cmpstr(mib_prt_get_client_info(token), ==, "client-info-value");
+	g_assert_cmpstr(mib_prt_get_id_token(token), ==, "id-token-value");
+	g_assert_cmpint(mib_prt_get_expires_on(token), ==, 1700000000);
+
+	gchar *const *granted = mib_prt_get_granted_scopes(token);
+	g_assert_nonnull(granted);
+	g_assert_cmpstr(granted[0], ==, "https://graph.microsoft.com/.default");
+
+	g_slist_free(scopes);
+	g_object_unref(token);
+	g_object_unref(account);
+	g_object_unref(app);
+}
+
+static void test_acquire_token_silent_bad_response(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+	mock_broker_set_acquire_token_silently_response(
+		broker, "{\"error\":\"something\"}");
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	MIBAccount *account =
+		mib_client_app_get_account_by_upn(app, "testuser@example.com");
+	g_assert_nonnull(account);
+
+	GSList *scopes = g_slist_append(NULL, (gpointer)MIB_SCOPE_GRAPH_DEFAULT);
+	MIBPrt *token = mib_client_app_acquire_token_silent(app, account, scopes,
+														NULL, NULL, NULL);
+	g_assert_null(token);
+
+	g_slist_free(scopes);
+	g_object_unref(account);
+	g_object_unref(app);
+}
+
+/* --- Test: acquire PRT SSO cookie --- */
+
+static void test_acquire_prt_sso_cookie(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+	mock_broker_set_acquire_prt_sso_cookie_response(broker,
+													PRT_SSO_COOKIE_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	MIBAccount *account =
+		mib_client_app_get_account_by_upn(app, "testuser@example.com");
+	g_assert_nonnull(account);
+
+	GSList *scopes = g_slist_append(NULL, (gpointer)MIB_SCOPE_GRAPH_DEFAULT);
+	MIBPrtSsoCookie *cookie = mib_client_app_acquire_prt_sso_cookie(
+		app, account, MIB_SSO_URL_DEFAULT, scopes);
+	g_assert_nonnull(cookie);
+
+	g_assert_cmpstr(mib_prt_sso_cookie_get_name(cookie), ==,
+					"x-ms-RefreshTokenCredential");
+	g_assert_cmpstr(mib_prt_sso_cookie_get_content(cookie), ==,
+					"cookie-content-value");
+
+	g_slist_free(scopes);
+	g_object_unref(cookie);
+	g_object_unref(account);
+	g_object_unref(app);
+}
+
+/* --- Test: generate signed HTTP request --- */
+
+static void test_generate_signed_http_request(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+	mock_broker_set_generate_signed_http_request_response(
+		broker, SIGNED_HTTP_REQUEST_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	MIBAccount *account =
+		mib_client_app_get_account_by_upn(app, "testuser@example.com");
+	g_assert_nonnull(account);
+
+	gchar *signed_req =
+		mib_client_app_generate_signed_http_request(app, account, NULL);
+	g_assert_nonnull(signed_req);
+	g_assert_cmpstr(signed_req, ==, "signed-request-token-value");
+
+	g_free(signed_req);
+	g_object_unref(account);
+	g_object_unref(app);
+}
+
+/* --- Test: remove account --- */
+
+static void test_remove_account(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_RESPONSE);
+	mock_broker_set_remove_account_response(broker, "{}");
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	MIBAccount *account =
+		mib_client_app_get_account_by_upn(app, "testuser@example.com");
+	g_assert_nonnull(account);
+
+	int ret = mib_client_app_remove_account(app, account);
+	g_assert_cmpint(ret, ==, 0);
+
+	g_object_unref(account);
+	g_object_unref(app);
+}
+
+/* --- Test: get Linux broker version --- */
+
+static void test_get_linux_broker_version(void)
+{
+	GError *error = NULL;
+	mock_broker_set_get_linux_broker_version_response(broker,
+													  BROKER_VERSION_RESPONSE);
+
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	gchar *version = mib_client_app_get_linux_broker_version(app, "1.28.0");
+	g_assert_nonnull(version);
+	g_assert_cmpstr(version, ==, "2.1.0");
+
+	g_free(version);
+	g_object_unref(app);
+}
+
+/* --- Test: enforce interactive flag --- */
+
+static void test_enforce_interactive(void)
+{
+	GError *error = NULL;
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	g_assert_cmpint(mib_client_app_get_enforce_interactive(app), ==, 0);
+	mib_client_app_set_enforce_interactive(app, 1);
+	g_assert_cmpint(mib_client_app_get_enforce_interactive(app), ==, 1);
+
+	g_object_unref(app);
+}
+
+/* --- Test: redirect URI --- */
+
+static void test_redirect_uri(void)
+{
+	GError *error = NULL;
+	MIBClientApp *app = mib_public_client_app_new(
+		TEST_CLIENT_ID, MIB_AUTHORITY_COMMON, NULL, &error);
+	g_assert_no_error(error);
+
+	gchar *default_uri = mib_client_app_get_broker_redirect_uri(app);
+	g_assert_nonnull(default_uri);
+	g_free(default_uri);
+
+	mib_client_app_set_redirect_uri(app, "https://custom.redirect/uri");
+
+	/* Verify by doing a get_accounts call and checking the request JSON
+	 * contains the custom URI */
+	mock_broker_set_get_accounts_response(broker, GET_ACCOUNTS_EMPTY_RESPONSE);
+	mib_client_app_get_accounts(app);
+
+	const gchar *last_req = mock_broker_get_last_request(broker, "getAccounts");
+	g_assert_nonnull(last_req);
+	g_assert_nonnull(g_strstr_len(last_req, -1, "https://custom.redirect/uri"));
+
+	g_object_unref(app);
+}
+
+int main(int argc, char *argv[])
+{
+	g_test_init(&argc, &argv, NULL);
+
+	broker = mock_broker_new();
+
+	g_test_add_func("/client-app/new", test_client_app_new);
+	g_test_add_func("/client-app/new-invalid-id",
+					test_client_app_new_invalid_id);
+	g_test_add_func("/client-app/get-accounts", test_get_accounts);
+	g_test_add_func("/client-app/get-accounts-empty", test_get_accounts_empty);
+	g_test_add_func("/client-app/get-account-by-upn", test_get_account_by_upn);
+	g_test_add_func("/client-app/get-account-by-upn-not-found",
+					test_get_account_by_upn_not_found);
+	g_test_add_func("/client-app/get-account-by-upn-null",
+					test_get_account_by_upn_null);
+	g_test_add_func("/client-app/acquire-token-silent",
+					test_acquire_token_silent);
+	g_test_add_func("/client-app/acquire-token-silent-bad-response",
+					test_acquire_token_silent_bad_response);
+	g_test_add_func("/client-app/acquire-prt-sso-cookie",
+					test_acquire_prt_sso_cookie);
+	g_test_add_func("/client-app/generate-signed-http-request",
+					test_generate_signed_http_request);
+	g_test_add_func("/client-app/remove-account", test_remove_account);
+	g_test_add_func("/client-app/get-linux-broker-version",
+					test_get_linux_broker_version);
+	g_test_add_func("/client-app/enforce-interactive",
+					test_enforce_interactive);
+	g_test_add_func("/client-app/redirect-uri", test_redirect_uri);
+
+	int ret = g_test_run();
+
+	mock_broker_free(broker);
+	return ret;
+}


### PR DESCRIPTION
Some projects currently cannot use the sso-mib, as all calls are performed synchronously. By that, the calls cannot be made from event loops that drive an UI. One such example is the evolution mail client.

To properly solve this, we now provide async variants of all currently blocking calls. To reduce code duplication, we do a major refactoring upfront.