### PR TITLE
fix: Export GLib object type cast symbols

### DIFF
--- a/include/mib-account.h
+++ b/include/mib-account.h
@@ -26,6 +26,7 @@ G_BEGIN_DECLS
 #ifndef DOXYGEN
 #define MIB_TYPE_ACCOUNT mib_account_get_type()
 G_DECLARE_FINAL_TYPE(MIBAccount, mib_account, MIB, ACCOUNT, GObject)
+PUBLIC_API GType mib_account_get_type(void);
 #else
 typedef void* MIBAccount;
 #endif

--- a/include/mib-client-app.h
+++ b/include/mib-client-app.h
@@ -53,6 +53,7 @@ enum MIB_PROMPT {
 #ifndef DOXYGEN
 #define MIB_TYPE_CLIENT_APP mib_client_app_get_type()
 G_DECLARE_FINAL_TYPE(MIBClientApp, mib_client_app, MIB, CLIENT_APP, GObject)
+PUBLIC_API GType mib_client_app_get_type(void);
 #else
 typedef void *MIBClientApp;
 #endif

--- a/include/mib-pop-params.h
+++ b/include/mib-pop-params.h
@@ -40,6 +40,7 @@ enum MIB_REQUEST_METHOD {
 #ifndef DOXYGEN
 #define MIB_TYPE_POP_PARAMS mib_pop_params_get_type()
 G_DECLARE_FINAL_TYPE(MIBPopParams, mib_pop_params, MIB, POP_PARAMS, GObject)
+PUBLIC_API GType mib_pop_params_get_type(void);
 #else
 typedef void* MIBPopParams;
 #endif

--- a/include/mib-prt-sso-cookie.h
+++ b/include/mib-prt-sso-cookie.h
@@ -27,6 +27,7 @@ G_BEGIN_DECLS
 #define MIB_TYPE_PRT_SSO_COOKIE mib_prt_sso_cookie_get_type()
 G_DECLARE_FINAL_TYPE(MIBPrtSsoCookie, mib_prt_sso_cookie, MIB, PRT_SSO_COOKIE,
 					 GObject)
+PUBLIC_API GType mib_prt_sso_cookie_get_type(void);
 #else
 typedef void* MIBPrtSsoCookie;
 #endif

--- a/include/mib-prt.h
+++ b/include/mib-prt.h
@@ -26,6 +26,7 @@ G_BEGIN_DECLS
 #ifndef DOXYGEN
 #define MIB_TYPE_PRT mib_prt_get_type()
 G_DECLARE_FINAL_TYPE(MIBPrt, mib_prt, MIB, PRT, GObject)
+PUBLIC_API GType mib_prt_get_type(void);
 #else
 typedef void* MIBPrt;
 #endif


### PR DESCRIPTION
To be able to use the GLib type cast macros, we need to export the underlying type conversion functions.

Fixes: 4ec6799 ("Initial OSS release")