### PR TITLE
feat: do not activate broker on app creation

### DIFF
--- a/include/mib-client-app.h
+++ b/include/mib-client-app.h
@@ -64,6 +64,12 @@ typedef void *MIBClientApp;
  * This function creates a new session for the given client_id.
  * The user is responsible for freeing the object with \c g_object_unref .
  *
+ * Since version \c 0.10.1 , this function no longer triggers a DBus
+ * activation of the broker service. Instead, the service is activated
+ * on demand by the individual method calls. As a result, a
+ * \c MIBClientApp object can be long-lived and remains valid across
+ * broker restarts.
+ *
  * \param client_id Azure client application ID
  * \param authority Azure authority URL (e.g. value from MIB_AUTHORITY_COMMON)
  * \param cancellable Cancellable object or NULL

--- a/src/mib-client-app.c
+++ b/src/mib-client-app.c
@@ -130,7 +130,8 @@ MIBClientApp *mib_public_client_app_new(const gchar *client_id,
 	}
 
 	self->broker = mib_dbus_identity_broker1_proxy_new_for_bus_sync(
-		G_BUS_TYPE_SESSION, G_DBUS_PROXY_FLAGS_NONE, DBUS_BROKER_NAME,
+		G_BUS_TYPE_SESSION,
+		G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START_AT_CONSTRUCTION, DBUS_BROKER_NAME,
 		DBUS_BROKER_PATH, self->cancellable, error);
 
 	if (!self->broker) {


### PR DESCRIPTION
We no longer trigger a DBus activation of the broker service on app creation. By that, app creation is fast and app instances can be used across broker restarts.

@rupran This change is probably also relevant for freerdp.